### PR TITLE
bug : snippet 없을 때, 에러 발생

### DIFF
--- a/test/src/main/kotlin/kpring/test/restdoc/dsl/RestDocBuilder.kt
+++ b/test/src/main/kotlin/kpring/test/restdoc/dsl/RestDocBuilder.kt
@@ -16,7 +16,6 @@ fun WebTestClient.BodyContentSpec.restDoc(
     if (builder.responseHeader != null) snippets.add(builder.responseHeader!!)
     if (builder.responseBody != null) snippets.add(builder.responseBody!!)
 
-    if (snippets.isEmpty()) throw IllegalArgumentException("must input api spec at restDoc()")
     return this.consumeWith(WebTestClientRestDocumentation.document(identifier, *snippets.toTypedArray()))
 }
 


### PR DESCRIPTION
## 📝작업 내용
Spring Rest Doc DSL 사용시 request와 response에 특별한 스펙이 없는 테스트에서 에러를 발생하는 문제를 해결하기 위해서 snippet이 전혀 없는 테스트 케이스를 작성하더라도 에러가 발생하지 않도록 변경하였습니다.