### PR TITLE
fix : mockMvc dsl 연동 버그

### DIFF
--- a/test/src/main/kotlin/kpring/test/restdoc/dsl/RestDocBuilder.kt
+++ b/test/src/main/kotlin/kpring/test/restdoc/dsl/RestDocBuilder.kt
@@ -1,7 +1,7 @@
 package kpring.test.restdoc.dsl
 
-import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper
 import com.epages.restdocs.apispec.WebTestClientRestDocumentationWrapper
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation
 import org.springframework.restdocs.snippet.Snippet
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.servlet.ResultActionsDsl
@@ -33,11 +33,7 @@ fun ResultActionsDsl.restDoc(
 
     this.andDo {
         handle(
-            MockMvcRestDocumentationWrapper.document(
-                identifier = identifier,
-                description = description,
-                snippets = builder.snippets.toTypedArray()
-            )
+            MockMvcRestDocumentation.document(identifier, *builder.snippets.toTypedArray())
         )
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#24 

## 📝작업 내용
mockMvc를 통한 rest docs 생성시 버그를 수정했습니다.
