### PR TITLE
[user] 회원정보 수정 API 실패 테스트

### DIFF
--- a/user/src/main/kotlin/kpring/user/controller/ExceptionController.java
+++ b/user/src/main/kotlin/kpring/user/controller/ExceptionController.java
@@ -46,7 +46,7 @@ public class ExceptionController {
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<FailMessageResponse> handleRuntimeException(RuntimeException e) {
         log.error("Internal server error", e);
-        var response = FailMessageResponse.builder().message("서버 오류").build();
+        var response = FailMessageResponse.serverError;
         return ResponseEntity.internalServerError()
                 .body(response);
     }

--- a/user/src/main/kotlin/kpring/user/dto/result/FailMessageResponse.java
+++ b/user/src/main/kotlin/kpring/user/dto/result/FailMessageResponse.java
@@ -6,4 +6,6 @@ import lombok.Builder;
 public record FailMessageResponse(
         String message
 ) {
+
+    public static final FailMessageResponse serverError = FailMessageResponse.builder().message("서버 오류").build();
 }

--- a/user/src/main/kotlin/kpring/user/dto/result/UpdateUserProfileResponse.java
+++ b/user/src/main/kotlin/kpring/user/dto/result/UpdateUserProfileResponse.java
@@ -3,5 +3,7 @@ package kpring.user.dto.result;
 import lombok.Builder;
 
 @Builder
-public record UpdateUserProfileResponse() {
+public record UpdateUserProfileResponse(
+        String email
+) {
 }

--- a/user/src/main/kotlin/kpring/user/exception/ErrorCode.java
+++ b/user/src/main/kotlin/kpring/user/exception/ErrorCode.java
@@ -6,6 +6,7 @@ public enum ErrorCode {
     // BAD_REQUEST
     ALREADY_EXISTS_EMAIL(HttpStatus.BAD_REQUEST, 4001, "Email already exists"),
     INVALID_EMAIL(HttpStatus.BAD_REQUEST, 4002, "Invalid email"),
+    NOT_ALLOWED(HttpStatus.FORBIDDEN, 4003, "Not allowed"), // 권한이 없는 경우
     ;
     public final HttpStatus status;
     public final int code;
@@ -17,7 +18,7 @@ public enum ErrorCode {
         this.message = message;
     }
 
-    public boolean isServerError(){
+    public boolean isServerError() {
         return status.is5xxServerError();
     }
 }


### PR DESCRIPTION

## #️⃣연관된 이슈

#21 
## 📝작업 내용
회원정보 수정 API 실패 테스트를 작성했어요.
* 권한이 없는 토큰 사용시 403
* 서버 내부 오류 발생시 500

AuthClient를 통해서 Auth 서버를 호출하는 코드가 추가되었어요.

