### PR TITLE
[Auth] validation API 스펙 변경

### DIFF
--- a/auth/src/main/kotlin/kpring/auth/api/v1/AuthController.kt
+++ b/auth/src/main/kotlin/kpring/auth/api/v1/AuthController.kt
@@ -2,7 +2,6 @@ package kpring.auth.api.v1
 
 import kpring.auth.service.TokenService
 import kpring.core.auth.dto.request.CreateTokenRequest
-import kpring.core.auth.dto.request.TokenValidationRequest
 import kpring.core.auth.dto.response.CreateTokenResponse
 import kpring.core.auth.dto.response.ReCreateAccessTokenResponse
 import kpring.core.auth.dto.response.TokenValidationResponse
@@ -47,9 +46,8 @@ class AuthController(
     @PostMapping("/validation")
     suspend fun validateToken(
         @RequestHeader("Authorization") token: String,
-        @Validated @RequestBody request: TokenValidationRequest,
     ): ResponseEntity<TokenValidationResponse> {
-        val response = tokenService.checkToken(token.removePrefix("Bearer "), request)
+        val response = tokenService.checkToken(token.removePrefix("Bearer "))
         return ResponseEntity.ok()
             .body(response)
     }

--- a/auth/src/main/kotlin/kpring/auth/service/TokenService.kt
+++ b/auth/src/main/kotlin/kpring/auth/service/TokenService.kt
@@ -7,7 +7,6 @@ import kpring.auth.repository.ExpireTokenRepository
 import kpring.auth.util.toObject
 import kpring.auth.util.toToken
 import kpring.core.auth.dto.request.CreateTokenRequest
-import kpring.core.auth.dto.request.TokenValidationRequest
 import kpring.core.auth.dto.response.CreateTokenResponse
 import kpring.core.auth.dto.response.ReCreateAccessTokenResponse
 import kpring.core.auth.dto.response.TokenValidationResponse
@@ -68,16 +67,15 @@ class TokenService(
         }
     }
 
-    suspend fun checkToken(token: String, request: TokenValidationRequest): TokenValidationResponse {
+    suspend fun checkToken(token: String): TokenValidationResponse {
         return try {
             val jwt = token.toObject(signingKey)
 
-            val isValid = request.userId == jwt.userId  &&
-                    !tokenRepository.isExpired(token)
+            val isValid = !tokenRepository.isExpired(token)
 
-            TokenValidationResponse(isValid, jwt.type)
+            TokenValidationResponse(isValid, jwt.type, jwt.userId)
         } catch (ex: TokenExpiredException) {
-            TokenValidationResponse(false, null)
+            TokenValidationResponse(false, null, null)
         }
     }
 }

--- a/auth/src/test/kotlin/kpring/auth/service/TokenServiceTest.kt
+++ b/auth/src/test/kotlin/kpring/auth/service/TokenServiceTest.kt
@@ -13,7 +13,6 @@ import kpring.auth.exception.TokenExpiredException
 import kpring.auth.repository.ExpireTokenRepository
 import kpring.auth.util.toToken
 import kpring.core.auth.dto.request.CreateTokenRequest
-import kpring.core.auth.dto.request.TokenValidationRequest
 import kpring.core.auth.enums.TokenType
 import java.nio.charset.StandardCharsets
 import java.time.LocalDateTime
@@ -81,8 +80,7 @@ class TokenServiceTest : BehaviorSpec({
                 .toToken(TokenType.REFRESH, otherKey, 100000)
             then("토큰 검증시 예외가 발생한다.") {
                 shouldThrow<IllegalArgumentException> {
-                    val request = TokenValidationRequest(userId = "testUserId");
-                    tokenService.checkToken(invalidTokenInfo.token, request)
+                    tokenService.checkToken(invalidTokenInfo.token)
                 }
             }
 
@@ -96,8 +94,7 @@ class TokenServiceTest : BehaviorSpec({
         When("만료된 토큰이라면") {
             coEvery { tokenRepository.isExpired(any()) } returns true
             then("토큰 검증시 isValid 응답은 false다.") {
-                val request = TokenValidationRequest(userId = "testUserId");
-                val response = tokenService.checkToken(tokenInfo.accessToken, request)
+                val response = tokenService.checkToken(tokenInfo.accessToken)
                 response.isValid shouldBe false
             }
         }
@@ -108,8 +105,7 @@ class TokenServiceTest : BehaviorSpec({
             val expiredToken = CreateTokenRequest("test", "nick").toToken(TokenType.ACCESS, validKey, -1).token
             coEvery { tokenRepository.isExpired(any()) } returns true
             then("토큰 검증시 isValid 응답은 false다.") {
-                val request = TokenValidationRequest(userId = "testUserId");
-                val response = tokenService.checkToken(expiredToken, request)
+                val response = tokenService.checkToken(expiredToken)
                 response.isValid shouldBe false
             }
 

--- a/core/src/main/kotlin/kpring/core/auth/dto/request/TokenValidationRequest.kt
+++ b/core/src/main/kotlin/kpring/core/auth/dto/request/TokenValidationRequest.kt
@@ -2,6 +2,7 @@ package kpring.core.auth.dto.request
 
 import jakarta.validation.constraints.NotBlank
 
+@Deprecated("삭제 예정입니다.")
 data class TokenValidationRequest(
     @NotBlank
     val userId: String

--- a/core/src/main/kotlin/kpring/core/auth/dto/response/TokenValidationResponse.kt
+++ b/core/src/main/kotlin/kpring/core/auth/dto/response/TokenValidationResponse.kt
@@ -5,4 +5,5 @@ import kpring.core.auth.enums.TokenType
 data class TokenValidationResponse(
     val isValid: Boolean,
     val type: TokenType?,
+    val userId: String?
 )


### PR DESCRIPTION
## #️⃣연관된 이슈

#14 

## 📝작업 내용

채팅 생성시 토큰으로 부터 유저의 id를 조회하기 위해서 토큰 검증 API의 스펙을 변경하였습니다.
Request body에 입력받은 userId를 통해서 토큰의 userId 정보와 일치하는지를 검사했던 기능을
현재는 토큰이 정상적으로 발급되었는지 만료되지 않았는지를 검사하여 유효성을 확인하고 토큰에 저장된 userId와 타입을 응답합니다.
