### PR TITLE
[Chat] queryDsl mongo 설정 및 셈플 코드 작성

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     id("io.spring.dependency-management") version "1.1.4"
     kotlin("jvm") version "1.9.23"
     kotlin("plugin.spring") version "1.9.23"
+    kotlin("kapt") version "1.9.23"
 }
 
 allprojects {

--- a/chat/build.gradle.kts
+++ b/chat/build.gradle.kts
@@ -5,10 +5,12 @@ plugins {
     id("io.spring.dependency-management") version "1.1.4"
     kotlin("jvm") version "1.9.23"
     kotlin("plugin.spring") version "1.9.23"
+    kotlin("kapt") version "1.9.23"
 }
 
 group = "kpring"
 version = "0.0.1-SNAPSHOT"
+val queryDslVersion = "5.1.0"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -22,11 +24,14 @@ dependencies {
     // core module
     api(project(":core"))
 
-    // webflux
-    implementation("org.springframework.boot:spring-boot-starter-webflux")
-
     // mongodb
+    implementation("jakarta.persistence:jakarta.persistence-api:3.1.0")
     implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
+    implementation("com.querydsl:querydsl-mongodb:${queryDslVersion}") {
+        exclude("org.mongodb", "mongo-java-driver")
+    }
+    implementation("com.querydsl:querydsl-jpa:${queryDslVersion}")
+    kapt("com.querydsl:querydsl-apt:${queryDslVersion}:jakarta")
 
     //web
     implementation("org.springframework.boot:spring-boot-starter-web")
@@ -36,16 +41,19 @@ dependencies {
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+
+    // kotest
+    testImplementation("io.kotest:kotest-assertions-core")
+    testImplementation("io.kotest:kotest-runner-junit5-jvm:5.8.0")
+    // mockk
+    testImplementation("io.mockk:mockk:1.13.10")
+    testImplementation("com.ninja-squad:springmockk:4.0.2")
+    // Spring rest docs
+    testImplementation("org.springframework.restdocs:spring-restdocs-webtestclient")
+    testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.3")
+    testImplementation("org.springframework.restdocs:spring-restdocs-asciidoctor")
+
+    // default test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-}
-
-tasks.withType<KotlinCompile> {
-    kotlinOptions {
-        freeCompilerArgs += "-Xjsr305=strict"
-        jvmTarget = "21"
-    }
-}
-
-tasks.withType<Test> {
-    useJUnitPlatform()
+    testImplementation(project(":test"))
 }

--- a/chat/compose.yml
+++ b/chat/compose.yml
@@ -1,0 +1,10 @@
+services:
+  mongo:
+    image: mongo:latest
+    container_name: mongo
+    ports:
+      - "27017:27017"
+    environment:
+        MONGO_INITDB_ROOT_USERNAME: root
+        MONGO_INITDB_ROOT_PASSWORD: 58155815
+        MONGO_INITDB_DATABASE: mongodb

--- a/chat/src/main/kotlin/kpring/chat/chat/model/Chat.kt
+++ b/chat/src/main/kotlin/kpring/chat/chat/model/Chat.kt
@@ -1,9 +1,11 @@
 package kpring.chat.chat.model
 
+import jakarta.persistence.Entity
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Document
 import java.time.LocalDateTime
 
+@Entity
 @Document(collection = "chats")
 class Chat(
     val userId: String,
@@ -16,7 +18,7 @@ class Chat(
 
     var isDeleted: Boolean = false
 
-    val sentAt: LocalDateTime = LocalDateTime.now()
+    var sentAt: LocalDateTime = LocalDateTime.now()
 
     fun deleted() {
         isDeleted = true

--- a/chat/src/main/kotlin/kpring/chat/chat/repository/ChatRepository.kt
+++ b/chat/src/main/kotlin/kpring/chat/chat/repository/ChatRepository.kt
@@ -2,8 +2,9 @@ package kpring.chat.chat.repository
 
 import kpring.chat.chat.model.Chat
 import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.data.querydsl.QuerydslPredicateExecutor
 import org.springframework.stereotype.Repository
 
 @Repository
-interface ChatRepository : MongoRepository<Chat,String> {
+interface ChatRepository : MongoRepository<Chat,String>, QuerydslPredicateExecutor<Chat>{
 }

--- a/chat/src/test/kotlin/kpring/chat/example/SampleTest.kt
+++ b/chat/src/test/kotlin/kpring/chat/example/SampleTest.kt
@@ -1,0 +1,69 @@
+package kpring.chat.example
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import kpring.chat.chat.model.Chat
+import kpring.chat.chat.model.QChat
+import kpring.chat.chat.repository.ChatRepository
+import org.springframework.boot.test.context.SpringBootTest
+
+/**
+ * querydsl mongoDB와 spring data mongo를 적용하는 예시 코드
+ */
+@SpringBootTest
+class SampleTest(
+    val chatRepository: ChatRepository
+) : DescribeSpec({
+
+    beforeTest {
+        chatRepository.deleteAll()
+    }
+
+    it("query dsl 적용 테스트"){
+        // given
+        repeat(5){ idx ->
+            chatRepository.save(
+                Chat("testUserId", "testRoomId", "testNickname$idx", "testContent")
+            )
+        }
+
+        // when
+        val result = chatRepository.findAll(
+            QChat.chat.userId.eq("testUserId"),
+            QChat.chat.userId.asc()
+        )
+
+        // then
+        result shouldHaveSize 5
+        result.forEach {
+            it.userId shouldBe "testUserId"
+            println("${it.nickname} : ${it.content}")
+        }
+    }
+
+    it("query dsl 적용 테스트 : 다중 조건") {
+        // given
+        chatRepository.deleteAll()
+        repeat(5){ idx ->
+            chatRepository.save(
+                Chat("testUserId", "testRoomId", "testNickname$idx", "testContent")
+            )
+        }
+
+        // when
+        val result = chatRepository.findAll(
+            QChat.chat.userId.eq("testUserId")
+                .and(QChat.chat.nickname.contains("testNickname"))
+                .and(null), // null을 적용하면 조건이 적용되지 않는다.
+            QChat.chat.nickname.desc()
+        )
+
+        // then
+        result shouldHaveSize 5
+        result.forEach {
+            it.userId shouldBe "testUserId"
+            println("${it.nickname} : ${it.content}")
+        }
+    }
+})


### PR DESCRIPTION
## #️⃣연관된 이슈

#43 

## 📝작업 내용

동적 쿼리 생성을 위해서 queryDsl 관련 설정을 추가했습니다.
ChatRepository를 통해서 queryDsl을 사용하는 예시 테스트를 작성하였습니다.

spring data 프로젝트에서 지원하는 QuerydslPrdicateExecutor를 상속받아 생성된 Qclass를 활용하는 방식으로 구현해보았습니다! 현재 구조에서는 객체를 포함하는 엔티티가 없기 때문에 현재 알아낸 방법으로 충분히 개발이 가능할 것 같아요!

## 💬리뷰 요구사항
queryDsl 예시 테스트 코드에서 작성된 예시의 코드 퀄리티에 대해서 궁금합니다.

## 참고 문서
https://github.com/404-nut-pound/spring-mongodb-querydsl-template
https://github.com/spring-projects/spring-data-examples/blob/main/mongodb/querydsl/README.md
