### PR TITLE
[Server] 서버 생성 API 테스트 추가

### DIFF
--- a/server/src/main/kotlin/kpring/server/adapter/input/rest/RestApiServerController.kt
+++ b/server/src/main/kotlin/kpring/server/adapter/input/rest/RestApiServerController.kt
@@ -2,6 +2,7 @@ package kpring.server.adapter.input.rest
 
 import kpring.core.auth.client.AuthClient
 import kpring.core.global.dto.response.ApiResponse
+import kpring.core.server.dto.ServerInfo
 import kpring.core.server.dto.request.AddUserAtServerRequest
 import kpring.core.server.dto.request.CreateServerRequest
 import kpring.server.application.port.input.AddUserAtServerUseCase
@@ -33,7 +34,7 @@ class RestApiServerController(
   @GetMapping("/{serverId}")
   fun getServerInfo(
     @PathVariable serverId: String
-  ): ResponseEntity<ApiResponse<*>> {
+  ): ResponseEntity<ApiResponse<ServerInfo>> {
     val data = getServerUseCase.getServerInfo(serverId)
     return ResponseEntity.ok()
       .body(ApiResponse(data = data))

--- a/server/src/test/kotlin/kpring/server/adapter/input/rest/RestApiServerControllerTest.kt
+++ b/server/src/test/kotlin/kpring/server/adapter/input/rest/RestApiServerControllerTest.kt
@@ -9,6 +9,7 @@ import io.mockk.junit5.MockKExtension
 import io.mockk.justRun
 import kpring.core.auth.client.AuthClient
 import kpring.core.global.dto.response.ApiResponse
+import kpring.core.server.dto.ServerInfo
 import kpring.core.server.dto.request.AddUserAtServerRequest
 import kpring.core.server.dto.request.CreateServerRequest
 import kpring.core.server.dto.response.CreateServerResponse
@@ -90,6 +91,46 @@ class RestApiServerControllerTest(
           body {
             "data.serverId" type "String" mean "서버 id"
             "data.serverName" type "String" mean "생성된 서버 이름"
+          }
+        }
+      }
+    }
+  }
+
+  describe("GET /api/v1/server/{serverId}: 서버 조회 api test") {
+
+    val url = "/api/v1/server/{serverId}"
+    it("요청 성공시") {
+      // given
+      val serverId = "test_server_id"
+      val data = ServerInfo(id = serverId, name = "test_server", users = emptyList())
+      every { serverService.getServerInfo(serverId) } returns data
+
+      // when
+      val result = webTestClient.get()
+        .uri(url, serverId)
+        .exchange()
+
+      // then
+      val docs = result
+        .expectStatus().isOk
+        .expectBody()
+        .json(objectMapper.writeValueAsString(ApiResponse(data = data)))
+
+      // docs
+      docs.restDoc(
+        identifier = "get_server_info_200",
+        description = "서버 단건 조회 api",
+      ) {
+        request {
+          path { "serverId" mean "서버 id" }
+        }
+
+        response {
+          body {
+            "data.id" type "String" mean "서버 id"
+            "data.name" type "String" mean "생성된 서버 이름"
+            "data.users" type "Array" mean "서버에 가입된 유저 목록"
           }
         }
       }

--- a/server/src/test/kotlin/kpring/server/adapter/input/rest/RestApiServerControllerTest.kt
+++ b/server/src/test/kotlin/kpring/server/adapter/input/rest/RestApiServerControllerTest.kt
@@ -16,15 +16,18 @@ import kpring.core.server.dto.request.AddUserAtServerRequest
 import kpring.core.server.dto.request.CreateServerRequest
 import kpring.core.server.dto.response.CreateServerResponse
 import kpring.server.application.service.ServerService
+import kpring.server.config.CoreConfiguration
 import kpring.test.restdoc.dsl.restDoc
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
 import org.springframework.restdocs.ManualRestDocumentation
 import org.springframework.restdocs.operation.preprocess.Preprocessors
 import org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation
 import org.springframework.test.web.servlet.client.MockMvcWebTestClient
 import org.springframework.web.context.WebApplicationContext
 
+@Import(CoreConfiguration::class)
 @WebMvcTest(controllers = [RestApiServerController::class])
 @ExtendWith(
   value = [
@@ -157,7 +160,7 @@ class RestApiServerControllerTest(
 
       // docs
       docs.restDoc(
-        identifier = "get_server_info_200",
+        identifier = "get_server_info_with_invalid_id",
         description = "서버 단건 조회 api",
       ) {
         request {
@@ -166,9 +169,7 @@ class RestApiServerControllerTest(
 
         response {
           body {
-            "data.id" type "String" mean "서버 id"
-            "data.name" type "String" mean "생성된 서버 이름"
-            "data.users" type "Array" mean "서버에 가입된 유저 목록"
+            "message" type "String" mean "실패 관련 메시지"
           }
         }
       }

--- a/server/src/test/kotlin/kpring/server/application/port/output/GetServerPortTest.kt
+++ b/server/src/test/kotlin/kpring/server/application/port/output/GetServerPortTest.kt
@@ -1,0 +1,29 @@
+package kpring.server.application.port.output
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import kpring.core.global.exception.CommonErrorCode
+import kpring.core.global.exception.ServiceException
+import kpring.test.testcontainer.SpringTestContext
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ContextConfiguration
+
+@SpringBootTest
+@ContextConfiguration(initializers = [SpringTestContext.SpringDataMongo::class])
+class GetServerPortTest(
+  val getServerPort: GetServerPort,
+) : DescribeSpec({
+  it("존재하지 서버 id를 조회하는 경우 에러가 발생한다.") {
+    // given
+    val notExistServerId = "notExistServerId"
+
+    // when
+    val ex = shouldThrow<ServiceException> {
+      getServerPort.get(notExistServerId)
+    }
+
+    // then
+    ex.errorCode shouldBe CommonErrorCode.NOT_FOUND
+  }
+})


### PR DESCRIPTION
## #️⃣연관된 이슈

> #75 

## 📝작업 내용

- 서버 생성 api 성공시 테스트 구현
- 서버 생성 api 실패(존재하지 않은 serverId 사용시) 테스트 구현
- 서버 조회 포트(repository) 인터페이스 테스트 구현 (존재하지 않은 serverId 사용시)