### PR TITLE
Feat/auth 회원가입 페이지 UI 렌더링 + 그 외

### DIFF
--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -3,6 +3,7 @@ import "./App.css";
 import Layout from "./components/Layout/Layout";
 import { PhaserGame } from "./components/Phaser/PhaserGame";
 import Home from "./pages/Home";
+import Join from "./pages/Join";
 import Login from "./pages/Login";
 function App() {
   return (
@@ -10,6 +11,7 @@ function App() {
       <BrowserRouter>
         <Routes>
           <Route path="/login" element={<Login />} />
+          <Route path="/join" element={<Join />} />
           <Route path="/" element={<Layout />}>
             <Route index element={<Home />} />
             <Route path="server/:serverId" element={<PhaserGame />} />

--- a/front/src/components/Auth/JoinBox.tsx
+++ b/front/src/components/Auth/JoinBox.tsx
@@ -3,7 +3,9 @@ import PersonAddAlt1Icon from "@mui/icons-material/PersonAddAlt1";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
+import { useNavigate } from "react-router";
 function JoinBox() {
+  const navigation = useNavigate();
   return (
     <section className="flex justify-center mt-[200px]">
       <div className="mt-[10px] w-[400px] text-center">
@@ -72,6 +74,7 @@ function JoinBox() {
               variant="text"
               startIcon={<LoginIcon />}
               sx={{ width: "50%" }}
+              onClick={() => navigation("/login")}
             >
               로그인 하러가기
             </Button>

--- a/front/src/components/Auth/JoinBox.tsx
+++ b/front/src/components/Auth/JoinBox.tsx
@@ -1,0 +1,85 @@
+import LoginIcon from "@mui/icons-material/Login";
+import PersonAddAlt1Icon from "@mui/icons-material/PersonAddAlt1";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
+function JoinBox() {
+  return (
+    <section className="flex justify-center mt-[200px]">
+      <div className="mt-[10px] w-[400px] text-center">
+        <Box
+          component="form"
+          sx={{
+            "& .MuiTextField-root": { mb: 3, width: "90%" },
+          }}
+          noValidate
+          autoComplete="off"
+          bgcolor="#fde2f34d
+          "
+          border="1px solid #e4d4e7"
+          padding="20px"
+        >
+          <h2 className="text-center text-2xl font-bold text-primary mt-[5px] mb-[10px]">
+            환영합니다!
+          </h2>{" "}
+          <TextField
+            required
+            id="user-name"
+            label="닉네임"
+            type="text"
+            placeholder="닉네임을 입력해주세요."
+            variant="standard"
+            size="small"
+          />
+          <TextField
+            required
+            id="user-email"
+            label="이메일"
+            placeholder="이메일을 입력해주세요."
+            variant="standard"
+            size="small"
+          />
+          <TextField
+            required
+            id="user-password"
+            label="비밀번호"
+            type="password"
+            placeholder="비밀번호를 입력해주세요."
+            autoComplete="current-password"
+            variant="standard"
+            size="small"
+          />
+          <TextField
+            required
+            id="user-password-confirm"
+            label="비밀번호 확인"
+            type="password"
+            placeholder="동일한 비밀번호를 입력해주세요."
+            autoComplete="current-password"
+            variant="standard"
+            size="small"
+          />
+          <div className="mt-[20px] flex justify-center flex-wrap ">
+            <Button
+              variant="contained"
+              color="secondary"
+              startIcon={<PersonAddAlt1Icon />}
+              sx={{ width: "90%", mb: "20px" }}
+            >
+              회원가입
+            </Button>
+            <Button
+              variant="text"
+              startIcon={<LoginIcon />}
+              sx={{ width: "50%" }}
+            >
+              로그인 하러가기
+            </Button>
+          </div>
+        </Box>
+      </div>
+    </section>
+  );
+}
+
+export default JoinBox;

--- a/front/src/components/Auth/LoginBox.tsx
+++ b/front/src/components/Auth/LoginBox.tsx
@@ -3,7 +3,9 @@ import PersonAddAlt1Icon from "@mui/icons-material/PersonAddAlt1";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
+import { useNavigate } from "react-router";
 function LoginBox() {
+  const navigation = useNavigate();
   return (
     <section className="flex justify-center mt-[200px]">
       <div className="mt-[30px] w-[400px] text-center">
@@ -54,6 +56,7 @@ function LoginBox() {
               color="secondary"
               startIcon={<PersonAddAlt1Icon />}
               sx={{ mt: "20px", width: "90%", mb: "20px" }}
+              onClick={() => navigation("/join")}
             >
               회원가입
             </Button>

--- a/front/src/components/Auth/LoginBox.tsx
+++ b/front/src/components/Auth/LoginBox.tsx
@@ -14,11 +14,12 @@ function LoginBox() {
           }}
           noValidate
           autoComplete="off"
-          bgcolor="#FDE2F3"
-          borderRadius="10px"
+          bgcolor="#fde2f34d
+          "
+          border="1px solid #e4d4e7"
           padding="20px"
         >
-          <h2 className="text-center text-2xl font-bold text-primary mb-[10px]">
+          <h2 className="text-center text-2xl font-bold text-primary mt-[5px] mb-[10px]">
             디코타운에 어서오세요!
           </h2>
           <TextField

--- a/front/src/pages/Join.tsx
+++ b/front/src/pages/Join.tsx
@@ -1,0 +1,29 @@
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+import JoinBox from "../components/Auth/JoinBox";
+const Login = () => {
+  const theme = createTheme({
+    palette: {
+      primary: {
+        light: "#FDE2F3",
+        main: "#917FB3",
+        dark: "#E5BEEC",
+        contrastText: "#fff",
+      },
+      secondary: {
+        light: "#2A2F4F",
+        main: "#2A2F4F",
+        dark: "#E5BEEC",
+        contrastText: "#fff",
+      },
+    },
+  });
+  return (
+    <div>
+      <ThemeProvider theme={theme}>
+        <JoinBox />
+      </ThemeProvider>
+    </div>
+  );
+};
+
+export default Login;


### PR DESCRIPTION
## #️⃣연관된 이슈

- 없음

## 📝작업 내용

1. 로그인 페이지 디자인 수정
- 좀 더 이쁘게 수정했습니다.  배경이 반투명이라서 전체 배경 넣어도 이쁠 것 같습니다.

2. 회원가입 페이지 추가와  UI 렌더링
- router에도 연결해두고, UI를 만들었습니다. 

3. 로그인과 회원가입 버튼 서로 연결 해뒀습니다.
- 로그인 페이지에서 회원가입 버튼을 누르면 회원가입 페이지로 이동
- 회원가입 페이지에서 로그인 하러가기 버튼 누르면 로그인 페이지로 이동

### 스크린샷 (선택)

#### 1번 스크린샷
![image](https://github.com/kSideProject/kpring/assets/143374855/626e9579-f169-4512-811e-3c41336cc9b6)

#### 2번 스크린샷
![image](https://github.com/kSideProject/kpring/assets/143374855/990b46d5-fff8-4523-9bdd-0b71982d2778)

## 💬리뷰 요구사항(선택)

> API 명세를 보니 유저이름과 이메일, 비밀번호만 있는것 같던데 혹시 추가 해야할 것이 있을까요? 
> 1차적인 UI 이므로 변동 될 가능성 있습니다. 