### PR TITLE
Feat/auth 테마 코드 이동, autocomplete Warning 해결, 회원가입 유효성 검사 추가

### DIFF
--- a/front/src/components/Auth/JoinBox.tsx
+++ b/front/src/components/Auth/JoinBox.tsx
@@ -113,7 +113,7 @@ function JoinBox() {
             id="user-password"
             label="비밀번호"
             type="password"
-            placeholder="숫자, 특수문자 포함 8자 이상 입력해주세요."
+            placeholder="대문자와 소문자, 숫자, 특수문자 포함 8~15자"
             autoComplete="current-password"
             variant="standard"
             size="small"

--- a/front/src/components/Auth/JoinBox.tsx
+++ b/front/src/components/Auth/JoinBox.tsx
@@ -31,6 +31,7 @@ function JoinBox() {
             type="text"
             placeholder="닉네임을 입력해주세요."
             variant="standard"
+            autoComplete="username"
             size="small"
           />
           <TextField
@@ -39,6 +40,7 @@ function JoinBox() {
             label="이메일"
             placeholder="이메일을 입력해주세요."
             variant="standard"
+            autoComplete="email"
             size="small"
           />
           <TextField

--- a/front/src/components/Auth/JoinBox.tsx
+++ b/front/src/components/Auth/JoinBox.tsx
@@ -8,22 +8,10 @@ import { JoinValidation } from "../../hooks/JoinValidation";
 
 function JoinBox() {
   const {
-    nickname,
-    setNickname,
-    email,
-    setEmail,
-    password,
-    setPassword,
-    passwordConfirm,
-    setPasswordConfirm,
-    nicknameError,
-    setNicknameError,
-    emailError,
-    setEmailError,
-    passwordError,
-    setPasswordError,
-    passwordConfirmError,
-    setPasswordConfirmError,
+    values,
+    setValues,
+    errors,
+    setErrors,
     validateNickname,
     validateEmail,
     validatePassword,
@@ -33,18 +21,20 @@ function JoinBox() {
   const clickSubmitHandler = (e: React.FormEvent) => {
     e.preventDefault();
 
-    const nicknameError = validateNickname(nickname);
-    const emailError = validateEmail(email);
-    const passwordError = validatePassword(password);
+    const nicknameError = validateNickname(values.nickname);
+    const emailError = validateEmail(values.email);
+    const passwordError = validatePassword(values.password);
     const passwordConfirmError = validatePasswordConfirm(
-      password,
-      passwordConfirm
+      values.password,
+      values.passwordConfirm
     );
 
-    setNicknameError(nicknameError);
-    setEmailError(emailError);
-    setPasswordError(passwordError);
-    setPasswordConfirmError(passwordConfirmError);
+    setErrors({
+      nicknameError,
+      emailError,
+      passwordError,
+      passwordConfirmError,
+    });
 
     if (
       !nicknameError &&
@@ -53,10 +43,12 @@ function JoinBox() {
       !passwordConfirmError
     ) {
       alert("회원가입 성공!");
-      setNickname("");
-      setEmail("");
-      setPassword("");
-      setPasswordConfirm("");
+      setValues({
+        nickname: "",
+        email: "",
+        password: "",
+        passwordConfirm: "",
+      });
     }
   };
 
@@ -90,10 +82,10 @@ function JoinBox() {
             variant="standard"
             autoComplete="username"
             size="small"
-            value={nickname}
-            onChange={(e) => setNickname(e.target.value)}
-            error={!!nicknameError}
-            helperText={nicknameError}
+            value={values.nickname}
+            onChange={(e) => setValues({ ...values, nickname: e.target.value })}
+            error={!!errors.nicknameError}
+            helperText={errors.nicknameError}
           />
           <TextField
             required
@@ -103,10 +95,10 @@ function JoinBox() {
             variant="standard"
             autoComplete="email"
             size="small"
-            onChange={(e) => setEmail(e.target.value)}
-            error={!!emailError}
-            helperText={emailError}
-            value={email}
+            value={values.email}
+            onChange={(e) => setValues({ ...values, email: e.target.value })}
+            error={!!errors.emailError}
+            helperText={errors.emailError}
           />
           <TextField
             required
@@ -117,10 +109,10 @@ function JoinBox() {
             autoComplete="current-password"
             variant="standard"
             size="small"
-            onChange={(e) => setPassword(e.target.value)}
-            error={!!passwordError}
-            helperText={passwordError}
-            value={password}
+            value={values.password}
+            onChange={(e) => setValues({ ...values, password: e.target.value })}
+            error={!!errors.passwordError}
+            helperText={errors.passwordError}
           />
           <TextField
             required
@@ -131,10 +123,12 @@ function JoinBox() {
             autoComplete="current-password"
             variant="standard"
             size="small"
-            onChange={(e) => setPasswordConfirm(e.target.value)}
-            error={!!passwordConfirmError}
-            helperText={passwordConfirmError}
-            value={passwordConfirm}
+            value={values.passwordConfirm}
+            onChange={(e) =>
+              setValues({ ...values, passwordConfirm: e.target.value })
+            }
+            error={!!errors.passwordConfirmError}
+            helperText={errors.passwordConfirmError}
           />
           <div className="mt-[20px] flex justify-center flex-wrap ">
             <Button

--- a/front/src/components/Auth/JoinBox.tsx
+++ b/front/src/components/Auth/JoinBox.tsx
@@ -4,8 +4,64 @@ import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
 import { useNavigate } from "react-router";
+import { JoinValidation } from "../../hooks/JoinValidation";
+
 function JoinBox() {
+  const {
+    nickname,
+    setNickname,
+    email,
+    setEmail,
+    password,
+    setPassword,
+    passwordConfirm,
+    setPasswordConfirm,
+    nicknameError,
+    setNicknameError,
+    emailError,
+    setEmailError,
+    passwordError,
+    setPasswordError,
+    passwordConfirmError,
+    setPasswordConfirmError,
+    validateNickname,
+    validateEmail,
+    validatePassword,
+    validatePasswordConfirm,
+  } = JoinValidation();
+
+  const clickSubmitHandler = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const nicknameError = validateNickname(nickname);
+    const emailError = validateEmail(email);
+    const passwordError = validatePassword(password);
+    const passwordConfirmError = validatePasswordConfirm(
+      password,
+      passwordConfirm
+    );
+
+    setNicknameError(nicknameError);
+    setEmailError(emailError);
+    setPasswordError(passwordError);
+    setPasswordConfirmError(passwordConfirmError);
+
+    if (
+      !nicknameError &&
+      !emailError &&
+      !passwordError &&
+      !passwordConfirmError
+    ) {
+      alert("회원가입 성공!");
+      setNickname("");
+      setEmail("");
+      setPassword("");
+      setPasswordConfirm("");
+    }
+  };
+
   const navigation = useNavigate();
+
   return (
     <section className="flex justify-center mt-[200px]">
       <div className="mt-[10px] w-[400px] text-center">
@@ -20,6 +76,7 @@ function JoinBox() {
           "
           border="1px solid #e4d4e7"
           padding="20px"
+          onSubmit={clickSubmitHandler}
         >
           <h2 className="text-center text-2xl font-bold text-primary mt-[5px] mb-[10px]">
             환영합니다!
@@ -33,6 +90,10 @@ function JoinBox() {
             variant="standard"
             autoComplete="username"
             size="small"
+            value={nickname}
+            onChange={(e) => setNickname(e.target.value)}
+            error={!!nicknameError}
+            helperText={nicknameError}
           />
           <TextField
             required
@@ -42,16 +103,24 @@ function JoinBox() {
             variant="standard"
             autoComplete="email"
             size="small"
+            onChange={(e) => setEmail(e.target.value)}
+            error={!!emailError}
+            helperText={emailError}
+            value={email}
           />
           <TextField
             required
             id="user-password"
             label="비밀번호"
             type="password"
-            placeholder="비밀번호를 입력해주세요."
+            placeholder="숫자, 특수문자 포함 8자 이상 입력해주세요."
             autoComplete="current-password"
             variant="standard"
             size="small"
+            onChange={(e) => setPassword(e.target.value)}
+            error={!!passwordError}
+            helperText={passwordError}
+            value={password}
           />
           <TextField
             required
@@ -62,9 +131,14 @@ function JoinBox() {
             autoComplete="current-password"
             variant="standard"
             size="small"
+            onChange={(e) => setPasswordConfirm(e.target.value)}
+            error={!!passwordConfirmError}
+            helperText={passwordConfirmError}
+            value={passwordConfirm}
           />
           <div className="mt-[20px] flex justify-center flex-wrap ">
             <Button
+              type="submit"
               variant="contained"
               color="secondary"
               startIcon={<PersonAddAlt1Icon />}

--- a/front/src/components/Auth/LoginBox.tsx
+++ b/front/src/components/Auth/LoginBox.tsx
@@ -31,6 +31,7 @@ function LoginBox() {
             placeholder="이메일을 입력해주세요."
             variant="standard"
             size="small"
+            autoComplete="email"
           />
           <TextField
             required
@@ -38,7 +39,7 @@ function LoginBox() {
             label="비밀번호"
             type="password"
             placeholder="비밀번호를 입력해주세요."
-            autoComplete="current-password"
+            autoComplete="password"
             variant="standard"
             size="small"
           />

--- a/front/src/components/Layout/Layout.tsx
+++ b/front/src/components/Layout/Layout.tsx
@@ -1,24 +1,9 @@
-import { ThemeProvider, createTheme } from "@mui/material/styles";
+import { ThemeProvider } from "@mui/material/styles";
 import { Outlet } from "react-router-dom";
+import theme from "../../theme/themeConfig";
 import Header from "./Header";
 import LeftSideBar from "./LeftSideBar";
 const Layout: React.FC = () => {
-  const theme = createTheme({
-    palette: {
-      primary: {
-        light: "#FDE2F3",
-        main: "#917FB3",
-        dark: "#FDE2F3",
-        contrastText: "#000",
-      },
-      secondary: {
-        light: "#2A2F4F",
-        main: "#2A2F4F",
-        dark: "#FDE2F3",
-        contrastText: "#fff",
-      },
-    },
-  });
   return (
     <div>
       <Header />

--- a/front/src/hooks/JoinValidation.ts
+++ b/front/src/hooks/JoinValidation.ts
@@ -1,14 +1,19 @@
 import { useState } from "react";
+import type { JoinBoxValidateErrors, JoinBoxValues } from "../types/join";
 export const JoinValidation = () => {
-  const [nickname, setNickname] = useState("");
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [passwordConfirm, setPasswordConfirm] = useState("");
+  const [values, setValues] = useState<JoinBoxValues>({
+    nickname: "",
+    email: "",
+    password: "",
+    passwordConfirm: "",
+  });
 
-  const [nicknameError, setNicknameError] = useState("");
-  const [emailError, setEmailError] = useState("");
-  const [passwordError, setPasswordError] = useState("");
-  const [passwordConfirmError, setPasswordConfirmError] = useState("");
+  const [errors, setErrors] = useState<JoinBoxValidateErrors>({
+    nicknameError: "",
+    emailError: "",
+    passwordError: "",
+    passwordConfirmError: "",
+  });
 
   const validateNickname = (nickname: string) => {
     if (!nickname) return "닉네임을 입력해주세요.";
@@ -42,22 +47,10 @@ export const JoinValidation = () => {
   };
 
   return {
-    nickname,
-    setNickname,
-    email,
-    setEmail,
-    password,
-    setPassword,
-    passwordConfirm,
-    setPasswordConfirm,
-    nicknameError,
-    setNicknameError,
-    emailError,
-    setEmailError,
-    passwordError,
-    setPasswordError,
-    passwordConfirmError,
-    setPasswordConfirmError,
+    values,
+    setValues,
+    errors,
+    setErrors,
     validateNickname,
     validateEmail,
     validatePassword,

--- a/front/src/hooks/JoinValidation.ts
+++ b/front/src/hooks/JoinValidation.ts
@@ -25,9 +25,10 @@ export const JoinValidation = () => {
 
   const validatePassword = (password: string) => {
     if (!password) return "비밀번호를 입력해주세요.";
-    const passwordRegex = /^(?=.*[a-z])(?=.*\d)(?=.*[!@#$%^&*]).{8,}$/;
+    const passwordRegex =
+      /^(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])[a-zA-Z0-9!@#$]{8,15}$/;
     if (!passwordRegex.test(password))
-      return "비밀번호는 소문자, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.";
+      return "비밀번호는 최소 8자에서 15자 사이, 대문자와 소문자, 숫자가 포함되어야 하며, 특수문자 ! @ # $도 사용할 수 있습니다.";
     return "";
   };
 

--- a/front/src/hooks/JoinValidation.ts
+++ b/front/src/hooks/JoinValidation.ts
@@ -1,0 +1,65 @@
+import { useState } from "react";
+export const JoinValidation = () => {
+  const [nickname, setNickname] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [passwordConfirm, setPasswordConfirm] = useState("");
+
+  const [nicknameError, setNicknameError] = useState("");
+  const [emailError, setEmailError] = useState("");
+  const [passwordError, setPasswordError] = useState("");
+  const [passwordConfirmError, setPasswordConfirmError] = useState("");
+
+  const validateNickname = (nickname: string) => {
+    if (!nickname) return "닉네임을 입력해주세요.";
+    if (nickname.length < 2) return "닉네임은 최소 2글자 이상이어야 합니다.";
+    return "";
+  };
+
+  const validateEmail = (email: string) => {
+    if (!email) return "이메일을 입력해주세요.";
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) return "올바른 이메일 형식이 아닙니다.";
+    return "";
+  };
+
+  const validatePassword = (password: string) => {
+    if (!password) return "비밀번호를 입력해주세요.";
+    const passwordRegex = /^(?=.*[a-z])(?=.*\d)(?=.*[!@#$%^&*]).{8,}$/;
+    if (!passwordRegex.test(password))
+      return "비밀번호는 소문자, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.";
+    return "";
+  };
+
+  const validatePasswordConfirm = (
+    password: string,
+    passwordConfirm: string
+  ) => {
+    if (!passwordConfirm) return "비밀번호 확인을 입력해주세요.";
+    if (password !== passwordConfirm) return "비밀번호가 일치하지 않습니다.";
+    return "";
+  };
+
+  return {
+    nickname,
+    setNickname,
+    email,
+    setEmail,
+    password,
+    setPassword,
+    passwordConfirm,
+    setPasswordConfirm,
+    nicknameError,
+    setNicknameError,
+    emailError,
+    setEmailError,
+    passwordError,
+    setPasswordError,
+    passwordConfirmError,
+    setPasswordConfirmError,
+    validateNickname,
+    validateEmail,
+    validatePassword,
+    validatePasswordConfirm,
+  };
+};

--- a/front/src/pages/Join.tsx
+++ b/front/src/pages/Join.tsx
@@ -1,22 +1,7 @@
-import { ThemeProvider, createTheme } from "@mui/material/styles";
+import { ThemeProvider } from "@mui/material/styles";
 import JoinBox from "../components/Auth/JoinBox";
+import theme from "../theme/themeConfig";
 const Login = () => {
-  const theme = createTheme({
-    palette: {
-      primary: {
-        light: "#FDE2F3",
-        main: "#917FB3",
-        dark: "#E5BEEC",
-        contrastText: "#fff",
-      },
-      secondary: {
-        light: "#2A2F4F",
-        main: "#2A2F4F",
-        dark: "#E5BEEC",
-        contrastText: "#fff",
-      },
-    },
-  });
   return (
     <div>
       <ThemeProvider theme={theme}>

--- a/front/src/pages/Login.tsx
+++ b/front/src/pages/Login.tsx
@@ -1,22 +1,7 @@
-import { ThemeProvider, createTheme } from "@mui/material/styles";
+import { ThemeProvider } from "@mui/material/styles";
 import LoginBox from "../components/Auth/LoginBox";
+import theme from "../theme/themeConfig";
 const Login = () => {
-  const theme = createTheme({
-    palette: {
-      primary: {
-        light: "#FDE2F3",
-        main: "#917FB3",
-        dark: "#E5BEEC",
-        contrastText: "#fff",
-      },
-      secondary: {
-        light: "#2A2F4F",
-        main: "#2A2F4F",
-        dark: "#E5BEEC",
-        contrastText: "#fff",
-      },
-    },
-  });
   return (
     <div>
       <ThemeProvider theme={theme}>

--- a/front/src/theme/themeConfig.ts
+++ b/front/src/theme/themeConfig.ts
@@ -1,0 +1,20 @@
+import { createTheme } from "@mui/material/styles";
+
+const theme = createTheme({
+  palette: {
+    primary: {
+      light: "#FDE2F3",
+      main: "#917FB3",
+      dark: "#E5BEEC",
+      contrastText: "#fff",
+    },
+    secondary: {
+      light: "#2A2F4F",
+      main: "#2A2F4F",
+      dark: "#E5BEEC",
+      contrastText: "#fff",
+    },
+  },
+});
+
+export default theme;

--- a/front/src/types/join.ts
+++ b/front/src/types/join.ts
@@ -1,0 +1,13 @@
+export type JoinBoxValues = {
+  nickname: string;
+  email: string;
+  password: string;
+  passwordConfirm: string;
+};
+
+export type JoinBoxValidateErrors = {
+  nicknameError: string;
+  emailError: string;
+  passwordError: string;
+  passwordConfirmError: string;
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

🎈

## 📝작업 내용

### 1. 테마 코드를 themeConfig.ts로 이동
-  Mui의 중복되는 테마 코드를 하나로 이동하였습니다. (themeConfig.ts)


### 2.  autocomplete 속성 관련 Warning 해결
- input 요소가 autocomplete 속성을 가지지 않아 발생하는 경고이므로 속성을 추가해주면 됩니다. 해결완료! 
![image](https://github.com/kSideProject/kpring/assets/143374855/52c27b00-084a-4ee3-8a8c-6bec16703c92)


### 3. 회원가입 페이지의 유효성 검사를 추가하였습니다.
![image](https://github.com/kSideProject/kpring/assets/143374855/7d6b2aab-fba6-45f1-ac45-5e63757a36f5)

아래와 같은 메세지로 출력됩니다.

1번째. 닉네임
1) 빈 칸인 경우 : 닉네임을 입력해주세요.
2) 닉네임이 최소 2글자가 아닌 경우 : 닉네임은 최소 2글자 이상이어야 합니다.

2번째. 이메일
1) 빈 칸인 경우 : 이메일을 입력해주세요.
2) 이메일 형식이 아닌 경우 : 올바른 이메일 형식이 아닙니다.

3번째. 비밀번호
1) 빈 칸인 경우 : 비밀번호를 입력해주세요.
2) 비밀번호 규칙에 안 맞는 경우 : 비밀번호는 소문자, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.

4번째. 비밀번호 확인
1) 빈 칸인 경우 : 비밀번호 확인을 입력해주세요.
2) 비밀번호와 동일하지 않는 경우 : 비밀번호가 일치하지 않습니다.

==========================================================\
## @yudonggeun 님의 조언에 따라 2가지 수정

### 1. 아래처럼 비밀번호 규칙 변경
1) 비밀번호는 최소 8자에서 15자 사이
2) 대문자, 소문자, 숫자가 포함되어야함
3) 특수문자 ! @ # $ 도 사용 가능

### 2. 회원가입 페이지의 상태관리하는 UseState를 Type과 객체로 변경해서 적용함
```
export type JoinBoxValues = {
  nickname: string;
  email: string;
  password: string;
  passwordConfirm: string;
};

export type JoinBoxValidateErrors = {
  nicknameError: string;
  emailError: string;
  passwordError: string;
  passwordConfirmError: string;
};

```
## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
일단 비밀번호는 소문자와 숫자, 특수문자 8자리 이상으로 했습니다. 특별히 원하는 비밀번호 규칙이 있을까요 ? 
```
const passwordRegex = /^(?=.*[a-z])(?=.*\d)(?=.*[!@#$%^&*]).{8,}$/;
```
