### PR TITLE
[Server] 서버 삭제 api 구현

### DIFF
--- a/server/src/main/kotlin/kpring/server/adapter/input/rest/RestApiServerController.kt
+++ b/server/src/main/kotlin/kpring/server/adapter/input/rest/RestApiServerController.kt
@@ -8,6 +8,7 @@ import kpring.core.server.dto.request.AddUserAtServerRequest
 import kpring.core.server.dto.request.CreateServerRequest
 import kpring.server.application.port.input.AddUserAtServerUseCase
 import kpring.server.application.port.input.CreateServerUseCase
+import kpring.server.application.port.input.DeleteServerUseCase
 import kpring.server.application.port.input.GetServerInfoUseCase
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -18,6 +19,7 @@ class RestApiServerController(
   val createServerUseCase: CreateServerUseCase,
   val getServerUseCase: GetServerInfoUseCase,
   val addUserAtServerUseCase: AddUserAtServerUseCase,
+  val deleteServerUseCase: DeleteServerUseCase,
   val authClient: AuthClient,
 ) {
   @PostMapping("")
@@ -77,7 +79,7 @@ class RestApiServerController(
     @RequestHeader("Authorization") token: String,
   ): ResponseEntity<Any> {
     val userInfo = authClient.getTokenInfo(token).data!!
-//    deleteServerUseCase.deleteServer(serverId, userInfo.userId)
+    deleteServerUseCase.deleteServer(serverId, userInfo.userId)
     return ResponseEntity.ok().build()
   }
 }

--- a/server/src/main/kotlin/kpring/server/adapter/input/rest/RestApiServerController.kt
+++ b/server/src/main/kotlin/kpring/server/adapter/input/rest/RestApiServerController.kt
@@ -70,4 +70,14 @@ class RestApiServerController(
     addUserAtServerUseCase.addInvitedUser(serverId, request)
     return ResponseEntity.ok().build()
   }
+
+  @DeleteMapping("/{serverId}")
+  fun deleteServer(
+    @PathVariable serverId: String,
+    @RequestHeader("Authorization") token: String,
+  ): ResponseEntity<Any> {
+    val userInfo = authClient.getTokenInfo(token).data!!
+//    deleteServerUseCase.deleteServer(serverId, userInfo.userId)
+    return ResponseEntity.ok().build()
+  }
 }

--- a/server/src/main/kotlin/kpring/server/adapter/output/mongo/DeleteServerPortMongoImpl.kt
+++ b/server/src/main/kotlin/kpring/server/adapter/output/mongo/DeleteServerPortMongoImpl.kt
@@ -1,0 +1,14 @@
+package kpring.server.adapter.output.mongo
+
+import kpring.server.adapter.output.mongo.repository.ServerRepository
+import kpring.server.application.port.output.DeleteServerPort
+import org.springframework.stereotype.Component
+
+@Component
+class DeleteServerPortMongoImpl(
+  val mongoRepository: ServerRepository,
+) : DeleteServerPort {
+  override fun delete(serverId: String) {
+    mongoRepository.deleteById(serverId)
+  }
+}

--- a/server/src/main/kotlin/kpring/server/application/port/input/DeleteServerUseCase.kt
+++ b/server/src/main/kotlin/kpring/server/application/port/input/DeleteServerUseCase.kt
@@ -1,0 +1,8 @@
+package kpring.server.application.port.input
+
+interface DeleteServerUseCase {
+  fun deleteServer(
+    serverId: String,
+    userId: String,
+  )
+}

--- a/server/src/main/kotlin/kpring/server/application/port/output/DeleteServerPort.kt
+++ b/server/src/main/kotlin/kpring/server/application/port/output/DeleteServerPort.kt
@@ -1,0 +1,5 @@
+package kpring.server.application.port.output
+
+interface DeleteServerPort {
+  fun delete(serverId: String)
+}

--- a/server/src/main/kotlin/kpring/server/application/service/ServerService.kt
+++ b/server/src/main/kotlin/kpring/server/application/service/ServerService.kt
@@ -10,7 +10,9 @@ import kpring.core.server.dto.request.CreateServerRequest
 import kpring.core.server.dto.response.CreateServerResponse
 import kpring.server.application.port.input.AddUserAtServerUseCase
 import kpring.server.application.port.input.CreateServerUseCase
+import kpring.server.application.port.input.DeleteServerUseCase
 import kpring.server.application.port.input.GetServerInfoUseCase
+import kpring.server.application.port.output.DeleteServerPort
 import kpring.server.application.port.output.GetServerPort
 import kpring.server.application.port.output.SaveServerPort
 import kpring.server.application.port.output.UpdateServerPort
@@ -24,7 +26,8 @@ class ServerService(
   val createServerPort: SaveServerPort,
   val getServer: GetServerPort,
   val updateServerPort: UpdateServerPort,
-) : CreateServerUseCase, GetServerInfoUseCase, AddUserAtServerUseCase {
+  val deleteServerPort: DeleteServerPort,
+) : CreateServerUseCase, GetServerInfoUseCase, AddUserAtServerUseCase, DeleteServerUseCase {
   override fun createServer(
     req: CreateServerRequest,
     userId: String,
@@ -77,5 +80,16 @@ class ServerService(
     val user = ServerUser(req.userId, req.userName, req.profileImage)
     server.addUser(user)
     updateServerPort.addUser(server.id, user)
+  }
+
+  override fun deleteServer(
+    serverId: String,
+    userId: String,
+  ) {
+    val server = getServer.get(serverId)
+    if (server.dontHasRole(userId, ServerAuthority.DELETE)) {
+      throw ServiceException(CommonErrorCode.FORBIDDEN)
+    }
+    deleteServerPort.delete(serverId)
   }
 }

--- a/server/src/test/kotlin/kpring/server/adapter/input/rest/RestApiServerControllerTest.kt
+++ b/server/src/test/kotlin/kpring/server/adapter/input/rest/RestApiServerControllerTest.kt
@@ -342,7 +342,7 @@ class RestApiServerControllerTest(
                 userId = "test_user_id",
               ),
           )
-//        justRun { serverService.deleteServer(serverId) }
+        justRun { serverService.deleteServer(eq(serverId), any()) }
 
         // when
         val result =

--- a/server/src/test/kotlin/kpring/server/adapter/input/rest/RestApiServerControllerTest.kt
+++ b/server/src/test/kotlin/kpring/server/adapter/input/rest/RestApiServerControllerTest.kt
@@ -327,4 +327,45 @@ class RestApiServerControllerTest(
         }
       }
     }
+
+    describe("DELETE /api/v1/server/{serverId} : 서버 삭제") {
+      val url = "/api/v1/server/{serverId}"
+      it("요청 성공시") {
+        // given
+        val serverId = "test_server_id"
+        val token = "Bearer mock_token"
+        every { authClient.getTokenInfo(token) } returns
+          ApiResponse(
+            data =
+              TokenInfo(
+                type = TokenType.ACCESS,
+                userId = "test_user_id",
+              ),
+          )
+//        justRun { serverService.deleteServer(serverId) }
+
+        // when
+        val result =
+          webTestClient.delete()
+            .uri(url, serverId)
+            .header("Authorization", token)
+            .exchange()
+
+        // then
+        val docs =
+          result
+            .expectStatus().isOk
+            .expectBody()
+
+        // docs
+        docs.restDoc(
+          identifier = "delete_server_200",
+          description = "서버 삭제 api",
+        ) {
+          request {
+            path { "serverId" mean "서버 id" }
+          }
+        }
+      }
+    }
   })

--- a/server/src/test/kotlin/kpring/server/application/port/input/DeleteServerUseCaseTest.kt
+++ b/server/src/test/kotlin/kpring/server/application/port/input/DeleteServerUseCaseTest.kt
@@ -13,17 +13,15 @@ import kpring.server.application.port.output.UpdateServerPort
 import kpring.server.application.service.ServerService
 import kpring.server.domain.Server
 
-class AddUserAtServerUseCaseTest(
+class DeleteServerUseCaseTest(
   val updateServerPort: UpdateServerPort = mockk(),
   val getServerPort: GetServerPort = mockk(),
   val deleteServerPort: DeleteServerPort = mockk(),
   val service: ServerService = ServerService(mockk(), getServerPort, updateServerPort, deleteServerPort),
 ) : DescribeSpec({
-
-    it("유저 초대시 초대하는 유저가 권한이 없다면 예외를 던진다") {
+    it("삭제하는 서버에 대한 삭제 권한이 없는 유저라면 예외가 발생한다.") {
       // given
       val serverId = "serverId"
-      val invitorId = "invitorId"
       val userId = "userId"
 
       every { getServerPort.get(serverId) } returns
@@ -35,7 +33,7 @@ class AddUserAtServerUseCaseTest(
       // when
       val ex =
         shouldThrow<ServiceException> {
-          service.inviteUser(serverId, invitorId, userId)
+          service.deleteServer(serverId, userId)
         }
 
       // then


### PR DESCRIPTION
## #️⃣연관된 이슈

- #104 

## 📝작업 내용

- 서버 삭제 API 구현
- 서버 소유 권한이 있는 경우에만 서버를 삭제하도록 구현하였습니다.
