### PR TITLE
[Chat] 서버 전체 채팅 생성 API 구현 

### DIFF
--- a/chat/src/main/kotlin/kpring/chat/chat/api/v1/ChatController.kt
+++ b/chat/src/main/kotlin/kpring/chat/chat/api/v1/ChatController.kt
@@ -2,7 +2,8 @@ package kpring.chat.chat.api.v1
 
 import kpring.chat.chat.service.ChatService
 import kpring.core.auth.client.AuthClient
-import kpring.core.chat.chat.dto.request.CreateChatRequest
+import kpring.core.chat.chat.dto.request.CreateRoomChatRequest
+import kpring.core.chat.chat.dto.request.CreateServerChatRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
@@ -13,13 +14,13 @@ class ChatController(
   private val chatService: ChatService,
   val authClient: AuthClient,
 ) {
-  @PostMapping("/chat")
-  fun createChat(
-    @Validated @RequestBody request: CreateChatRequest,
+  @PostMapping("/chat/chatroom")
+  fun createRoomChat(
+    @Validated @RequestBody request: CreateRoomChatRequest,
     @RequestHeader("Authorization") token: String,
   ): ResponseEntity<*> {
     val userId = authClient.getTokenInfo(token).data!!.userId
-    val result = chatService.createChat(request, userId)
+    val result = chatService.createRoomChat(request, userId)
     return ResponseEntity.ok().body(result)
   }
 

--- a/chat/src/main/kotlin/kpring/chat/chat/api/v1/ChatController.kt
+++ b/chat/src/main/kotlin/kpring/chat/chat/api/v1/ChatController.kt
@@ -24,6 +24,16 @@ class ChatController(
     return ResponseEntity.ok().body(result)
   }
 
+  @PostMapping("/chat/server")
+  fun createServerChat(
+    @Validated @RequestBody request: CreateServerChatRequest,
+    @RequestHeader("Authorization") token: String,
+  ): ResponseEntity<*> {
+    val userId = authClient.getTokenInfo(token).data!!.userId
+    val result = chatService.createServerChat(request, userId)
+    return ResponseEntity.ok().body(result)
+  }
+
   @GetMapping("/chat/{chatRoomId}/{page}")
   fun getChatsByChatRoom(
     @PathVariable("chatRoomId") chatRoomId: String,

--- a/chat/src/main/kotlin/kpring/chat/chat/model/ServerChat.kt
+++ b/chat/src/main/kotlin/kpring/chat/chat/model/ServerChat.kt
@@ -1,0 +1,21 @@
+package kpring.chat.chat.model
+
+import kpring.chat.NoArg
+import kpring.chat.global.model.BaseTime
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.mapping.Document
+
+@NoArg
+@Document(collection = "server_chats")
+class ServerChat(
+  userId: String,
+  val serverId: String,
+  val content: String,
+) : BaseTime() {
+  @Id
+  var id: String? = null
+
+  fun isEdited(): Boolean {
+    return !createdAt.equals(updatedAt)
+  }
+}

--- a/chat/src/main/kotlin/kpring/chat/chat/repository/RoomChatRepository.kt
+++ b/chat/src/main/kotlin/kpring/chat/chat/repository/RoomChatRepository.kt
@@ -7,7 +7,7 @@ import org.springframework.data.querydsl.QuerydslPredicateExecutor
 import org.springframework.stereotype.Repository
 
 @Repository
-interface ChatRepository : MongoRepository<Chat, String>, QuerydslPredicateExecutor<Chat> {
+interface RoomChatRepository : MongoRepository<Chat, String>, QuerydslPredicateExecutor<Chat> {
   fun findAllByRoomId(
     roomId: String,
     pageable: Pageable,

--- a/chat/src/main/kotlin/kpring/chat/chat/repository/ServerChatRepository.kt
+++ b/chat/src/main/kotlin/kpring/chat/chat/repository/ServerChatRepository.kt
@@ -1,0 +1,9 @@
+package kpring.chat.chat.repository
+
+import kpring.chat.chat.model.ServerChat
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.data.querydsl.QuerydslPredicateExecutor
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ServerChatRepository : MongoRepository<ServerChat, String>, QuerydslPredicateExecutor<ServerChat>

--- a/chat/src/main/kotlin/kpring/chat/chat/service/ChatService.kt
+++ b/chat/src/main/kotlin/kpring/chat/chat/service/ChatService.kt
@@ -1,11 +1,14 @@
 package kpring.chat.chat.service
 
 import kpring.chat.chat.model.Chat
-import kpring.chat.chat.repository.ChatRepository
+import kpring.chat.chat.model.ServerChat
+import kpring.chat.chat.repository.RoomChatRepository
+import kpring.chat.chat.repository.ServerChatRepository
 import kpring.chat.chatroom.repository.ChatRoomRepository
 import kpring.chat.global.exception.ErrorCode
 import kpring.chat.global.exception.GlobalException
-import kpring.core.chat.chat.dto.request.CreateChatRequest
+import kpring.core.chat.chat.dto.request.CreateRoomChatRequest
+import kpring.core.chat.chat.dto.request.CreateServerChatRequest
 import kpring.core.chat.chat.dto.response.ChatResponse
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.PageRequest
@@ -14,19 +17,20 @@ import org.springframework.stereotype.Service
 
 @Service
 class ChatService(
-  private val chatRepository: ChatRepository,
+  private val roomChatRepository: RoomChatRepository,
+  private val serverChatRepository: ServerChatRepository,
   private val chatRoomRepository: ChatRoomRepository,
   @Value("\${page.size}") val pageSize: Int = 100,
 ) {
   /*
      business logic
    */
-  fun createChat(
-    request: CreateChatRequest,
+  fun createRoomChat(
+    request: CreateRoomChatRequest,
     userId: String,
   ) {
     val chat =
-      chatRepository.save(
+      roomChatRepository.save(
         Chat(
           userId = userId,
           roomId = request.room,
@@ -44,7 +48,7 @@ class ChatService(
 
     // find chats by chatRoomId and convert them into DTOs
     val pageable: Pageable = PageRequest.of(page, pageSize)
-    val chats: List<Chat> = chatRepository.findAllByRoomId(chatRoomId, pageable)
+    val chats: List<Chat> = roomChatRepository.findAllByRoomId(chatRoomId, pageable)
 
     return convertChatsToResponses(chats)
   }

--- a/chat/src/main/kotlin/kpring/chat/chat/service/ChatService.kt
+++ b/chat/src/main/kotlin/kpring/chat/chat/service/ChatService.kt
@@ -53,6 +53,20 @@ class ChatService(
     return convertChatsToResponses(chats)
   }
 
+  fun createServerChat(
+    request: CreateServerChatRequest,
+    userId: String,
+  ) {
+    val chat =
+      serverChatRepository.save(
+        ServerChat(
+          userId = userId,
+          serverId = request.server,
+          content = request.content,
+        ),
+      )
+  }
+
   fun checkIfAuthorized(
     chatRoomId: String,
     userId: String,

--- a/chat/src/test/kotlin/kpring/chat/chatroom/ChatRoomServiceTest.kt
+++ b/chat/src/test/kotlin/kpring/chat/chatroom/ChatRoomServiceTest.kt
@@ -35,7 +35,8 @@ class ChatRoomServiceTest : FunSpec({
     // Given
     val chatRoom =
       ChatRoom().apply {
-        id = ChatRoomTest.TEST_ROOM_ID
+        id =
+          ChatRoomTest.TEST_ROOM_ID
         addUsers(ChatRoomTest.TEST_MEMBERS)
       }
     every { chatRoomRepository.findById(chatRoom.id!!) } returns Optional.of(chatRoom)

--- a/chat/src/test/kotlin/kpring/chat/example/SampleTest.kt
+++ b/chat/src/test/kotlin/kpring/chat/example/SampleTest.kt
@@ -5,7 +5,7 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import kpring.chat.chat.model.Chat
 import kpring.chat.chat.model.QChat
-import kpring.chat.chat.repository.ChatRepository
+import kpring.chat.chat.repository.RoomChatRepository
 import kpring.test.testcontainer.SpringTestContext
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ContextConfiguration
@@ -16,25 +16,25 @@ import org.springframework.test.context.ContextConfiguration
 @SpringBootTest
 @ContextConfiguration(initializers = [SpringTestContext.SpringDataMongo::class])
 class SampleTest(
-  val chatRepository: ChatRepository,
+  val roomChatRepository: RoomChatRepository,
 ) : DescribeSpec({
 
     beforeTest {
-      chatRepository.deleteAll()
+      roomChatRepository.deleteAll()
     }
 
     it("query dsl 적용 테스트") {
       // given
       val chat = QChat.chat
       repeat(5) { idx ->
-        chatRepository.save(
+        roomChatRepository.save(
           Chat("testUserId", "testRoomId", "testContent$idx"),
         )
       }
 
       // when
       val result =
-        chatRepository.findAll(
+        roomChatRepository.findAll(
           chat.userId.eq("testUserId"),
           chat.userId.asc(),
         )
@@ -50,16 +50,16 @@ class SampleTest(
     it("query dsl 적용 테스트 : 다중 조건") {
       // given
       val chat = QChat.chat
-      chatRepository.deleteAll()
+      roomChatRepository.deleteAll()
       repeat(5) { idx ->
-        chatRepository.save(
+        roomChatRepository.save(
           Chat("testUserId", "testRoomId", "testContent$idx"),
         )
       }
 
       // when
       val result =
-        chatRepository.findAll(
+        roomChatRepository.findAll(
           chat.userId.eq("testUserId")
             .and(chat.content.contains("testContent"))
             // null을 적용하면 조건이 적용되지 않는다.

--- a/core/src/main/kotlin/kpring/core/chat/chat/dto/request/CreateRoomChatRequest.kt
+++ b/core/src/main/kotlin/kpring/core/chat/chat/dto/request/CreateRoomChatRequest.kt
@@ -3,7 +3,7 @@ package kpring.core.chat.chat.dto.request
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 
-data class CreateChatRequest(
+data class CreateRoomChatRequest(
   @field:NotNull
   val room: String,
   @field:NotBlank

--- a/core/src/main/kotlin/kpring/core/chat/chat/dto/request/CreateServerChatRequest.kt
+++ b/core/src/main/kotlin/kpring/core/chat/chat/dto/request/CreateServerChatRequest.kt
@@ -1,0 +1,9 @@
+package kpring.core.chat.chat.dto.request
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+
+class CreateServerChatRequest(
+  @field:NotNull val server: String,
+  @field:NotBlank val content: String,
+)


### PR DESCRIPTION
## #️⃣연관된 이슈

#120

## 📝작업 내용

서버 전체 채팅 생성 기능을 구현했습니다!

## 💬리뷰 요구사항
채팅을 server id로 조회하는 경우랑 room id로 조회하는 경우가 생기는데 
server id로 조회하는 경우에 room id로 만들어진 채팅까지 봐야하면 불필요한 db 조회가 늘어날 것 같아서
기존의 Chat과 다른 ServerChat model을 따로 만들고 Repository도 분리했습니다
그냥 Chat에다가 nullable한 server id 필드를 추가하는게 나았을까요?

Controller layer에 
POST api/v1/chat/server -> server id로 Chat을 생성
POST api/v1/chat/room -> room id로 Chat을 생성
이렇게 두개로 분리했는데 
저게 restful 한 API인지 의문이 듭니다! 더 좋은 api가 있다면 건의해주시면 감사하겠습니다 ✨✨😉
