### PR TITLE
[Feat/favorite] 홈화면에 즐겨찾기된 서버 필터 

### DIFF
--- a/front/src/components/Home/FavoriteIcon.tsx
+++ b/front/src/components/Home/FavoriteIcon.tsx
@@ -1,0 +1,21 @@
+import useStore from "../../utils/store";
+import StarBorderIcon from "@mui/icons-material/StarBorder";
+import StarIcon from "@mui/icons-material/Star";
+import { useIsFavorite } from "../../hooks/Favorites";
+
+const FavoriteIcon = ({ id }: { id: string }) => {
+  const isFavorite = useIsFavorite(id);
+  const setFavorites = useStore((state) => state.setFavorites);
+
+  return (
+    <>
+      {!isFavorite ? (
+        <StarBorderIcon onClick={() => setFavorites(id, !isFavorite)} />
+      ) : (
+        <StarIcon onClick={() => setFavorites(id, !isFavorite)} />
+      )}
+    </>
+  );
+};
+
+export default FavoriteIcon;

--- a/front/src/components/Home/ServerCard.tsx
+++ b/front/src/components/Home/ServerCard.tsx
@@ -1,65 +1,25 @@
 import { Card, CardContent, CardMedia, Typography } from "@mui/material";
-import StarBorderIcon from "@mui/icons-material/StarBorder";
-import StarIcon from "@mui/icons-material/Star";
-import { useEffect, useState } from "react";
-import { serverData } from "../../utils/fakeData";
-import { FavoritesState } from "../../types/server";
+import FavoriteIcon from "./FavoriteIcon";
 
-const ServerCard = () => {
-  const [favorites, setFavorites] = useState<FavoritesState>({}); // 각각의 카드를 관리할 수 있는 객체
-  const [filteredServers, setFilteredServers] = useState(serverData); // api fetch data를 기본으로 설정하고 여기서 필터
-
-  // 즐겨찾기 아이콘을 클릭했을 때 일어나는 이벤트
-  const onClickFavorite = (id: string) => {
-    // 즐겨찾기 아이콘 토글
-    setFavorites((prevFavorites) => {
-      const newFavorites = {
-        ...prevFavorites, // 원래 즐겨찾기가 되어있는 카드(서버)들을 그대로 유지 (불변성 유지)
-        [id]: !prevFavorites[id], // 매개변수로 받은 서버의 id 값의 상태를 반전 업데이트(토글 형식)
-      };
-
-      // 전체 서버에서 즐겨찾기 된 서버만 필터링
-      const newFilteredServers = serverData.filter(
-        (server) => newFavorites[server.serverId]
-      );
-
-      // 필터된 서버로 업데이트/저장
-      setFilteredServers(newFilteredServers);
-      return newFavorites;
-    });
+const ServerCard = ({
+  servers,
+}: {
+  servers: {
+    serverId: string;
+    serverName: string;
+    image: string;
+    members: string[];
   };
-
-  useEffect(() => {
-    const initialFilteredServers = serverData.filter(
-      (server) => favorites[server.serverId]
-    );
-    setFilteredServers(initialFilteredServers);
-  }, [favorites]);
-
+}) => {
   return (
-    <div className="flex flex-wrap gap-3 ">
-      {filteredServers.map((server) => {
-        const isFavorite = favorites[server.serverId];
-
-        return (
-          <Card sx={{ width: 345, cursor: "pointer" }} key={server.serverId}>
-            <CardMedia sx={{ height: 140 }} image={server.image}></CardMedia>
-            <CardContent>
-              <Typography>{server.serverName}</Typography>
-              <Typography>{server.members.length}명</Typography>
-
-              {isFavorite ? (
-                <StarBorderIcon
-                  onClick={() => onClickFavorite(server.serverId)}
-                />
-              ) : (
-                <StarIcon onClick={() => onClickFavorite(server.serverId)} />
-              )}
-            </CardContent>
-          </Card>
-        );
-      })}
-    </div>
+    <Card sx={{ width: 345, cursor: "pointer" }} key={servers.serverId}>
+      <CardMedia sx={{ height: 140 }} image={servers.image}></CardMedia>
+      <CardContent>
+        <Typography>{servers.serverName}</Typography>
+        <Typography>{servers.members.length} 명</Typography>
+        <FavoriteIcon id={servers.serverId} />
+      </CardContent>
+    </Card>
   );
 };
 

--- a/front/src/components/Home/ServerCard.tsx
+++ b/front/src/components/Home/ServerCard.tsx
@@ -1,17 +1,60 @@
 import { Card, CardContent, CardMedia, Typography } from "@mui/material";
-import React from "react";
+import StarBorderIcon from "@mui/icons-material/StarBorder";
+import StarIcon from "@mui/icons-material/Star";
+import { useEffect, useState } from "react";
 import { serverData } from "../../utils/fakeData";
+import { FavoritesState } from "../../types/server";
 
 const ServerCard = () => {
+  const [favorites, setFavorites] = useState<FavoritesState>({}); // 각각의 카드를 관리할 수 있는 객체
+  const [filteredServers, setFilteredServers] = useState(serverData); // api fetch data를 기본으로 설정하고 여기서 필터
+
+  // 즐겨찾기 아이콘을 클릭했을 때 일어나는 이벤트
+  const onClickFavorite = (id: string) => {
+    // 즐겨찾기 아이콘 토글
+    setFavorites((prevFavorites) => {
+      const newFavorites = {
+        ...prevFavorites, // 원래 즐겨찾기가 되어있는 카드(서버)들을 그대로 유지 (불변성 유지)
+        [id]: !prevFavorites[id], // 매개변수로 받은 서버의 id 값의 상태를 반전 업데이트(토글 형식)
+      };
+
+      // 전체 서버에서 즐겨찾기 된 서버만 필터링
+      const newFilteredServers = serverData.filter(
+        (server) => newFavorites[server.serverId]
+      );
+
+      // 필터된 서버로 업데이트/저장
+      setFilteredServers(newFilteredServers);
+      return newFavorites;
+    });
+  };
+
+  useEffect(() => {
+    const initialFilteredServers = serverData.filter(
+      (server) => favorites[server.serverId]
+    );
+    setFilteredServers(initialFilteredServers);
+  }, [favorites]);
+
   return (
     <div className="flex flex-wrap gap-3 ">
-      {serverData.map((server) => {
+      {filteredServers.map((server) => {
+        const isFavorite = favorites[server.serverId];
+
         return (
-          <Card sx={{ width: 345, cursor: "pointer" }}>
+          <Card sx={{ width: 345, cursor: "pointer" }} key={server.serverId}>
             <CardMedia sx={{ height: 140 }} image={server.image}></CardMedia>
             <CardContent>
               <Typography>{server.serverName}</Typography>
               <Typography>{server.members.length}명</Typography>
+
+              {isFavorite ? (
+                <StarBorderIcon
+                  onClick={() => onClickFavorite(server.serverId)}
+                />
+              ) : (
+                <StarIcon onClick={() => onClickFavorite(server.serverId)} />
+              )}
             </CardContent>
           </Card>
         );

--- a/front/src/components/Home/ServerList.tsx
+++ b/front/src/components/Home/ServerList.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import ServerCard from "./ServerCard";
+import { useFilterFavorites } from "../../hooks/Favorites";
+
+const ServerList = ({
+  servers,
+}: {
+  servers: {
+    serverId: string;
+    serverName: string;
+    image: string;
+    members: string[];
+  }[];
+}) => {
+  const filteredFavorite = useFilterFavorites();
+
+  return (
+    <>
+      {servers
+        .filter((server) => filteredFavorite.includes(server.serverId))
+        .map((server) => (
+          <ServerCard key={server.serverId} servers={server} />
+        ))}
+    </>
+  );
+};
+
+export default ServerList;

--- a/front/src/components/Layout/ServerInfoSidebar.tsx
+++ b/front/src/components/Layout/ServerInfoSidebar.tsx
@@ -15,6 +15,7 @@ import { serverData } from "../../utils/fakeData";
 import MemberProfile from "../Profile/MemberProfile";
 import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
 import { useNavigate } from "react-router-dom";
+import FavoriteIcon from "../Home/FavoriteIcon";
 
 const ServerInfoSidebar: React.FC<ServerInforProps> = ({
   close,
@@ -40,6 +41,7 @@ const ServerInfoSidebar: React.FC<ServerInforProps> = ({
         <ArrowForwardIosIcon onClick={close} />
         <div>서버 멤버</div>
         <Button onClick={() => navigate(`server/${serverID}`)}>서버입장</Button>
+        <FavoriteIcon id={serverID} />
       </DrawerHeader>
       <Divider />
       <List>

--- a/front/src/hooks/Favorites.ts
+++ b/front/src/hooks/Favorites.ts
@@ -1,0 +1,11 @@
+import useStore from "../utils/store";
+
+export const useIsFavorite = (id: string) => {
+  return useStore((state) => state.favorites[id] ?? false);
+};
+
+export const useFilterFavorites = () => {
+  return useStore((state) =>
+    Object.keys(state.favorites).filter((id) => state.favorites[id])
+  );
+};

--- a/front/src/pages/Home.tsx
+++ b/front/src/pages/Home.tsx
@@ -1,13 +1,30 @@
 import ServerCard from "../components/Home/ServerCard";
+import Carousel from "react-material-ui-carousel";
+import { serverData } from "../utils/fakeData";
 
 const Home = () => {
   return (
-    <div className="my-24 mx-28">
-      <div className="">인기있는 서버들</div>
+    <div className="my-24 mx-36 text-cente">
+      <div className="flex flex-col gap-3 mb-12">
+        <div className="text-2xl">인기있는 서버들</div>
+        <Carousel autoPlay={true} height={400}>
+          {serverData.map((server) => {
+            return (
+              <div className="h-[400px]">
+                <img src={server.image} alt={server.serverName} />
+                <p className="absolute bottom-10 left-2 text-3xl">
+                  {server.serverName}
+                </p>
+              </div>
+            );
+          })}
+        </Carousel>
+      </div>
 
-      {/* API에 사용자가 서버에 접속한 마지막 시간을 기록할 수 있나요? */}
-      <h2 className="text-2xl">최근에 방문한 서버</h2>
-      <ServerCard />
+      <div className="flex flex-col gap-3">
+        <h2 className="text-2xl">즐겨찾기한 서버들</h2>
+        <ServerCard />
+      </div>
     </div>
   );
 };

--- a/front/src/pages/Home.tsx
+++ b/front/src/pages/Home.tsx
@@ -1,8 +1,17 @@
-import ServerCard from "../components/Home/ServerCard";
 import Carousel from "react-material-ui-carousel";
 import { serverData } from "../utils/fakeData";
+import { useEffect, useState } from "react";
+import ServerList from "../components/Home/ServerList";
 
 const Home = () => {
+  const [servers, setServers] = useState<
+    { serverId: string; serverName: string; image: string; members: string[] }[]
+  >([]);
+
+  useEffect(() => {
+    setServers(serverData);
+  }, []);
+
   return (
     <div className="my-24 mx-36 text-cente">
       <div className="flex flex-col gap-3 mb-12">
@@ -23,7 +32,7 @@ const Home = () => {
 
       <div className="flex flex-col gap-3">
         <h2 className="text-2xl">즐겨찾기한 서버들</h2>
-        <ServerCard />
+        <ServerList servers={servers}></ServerList>
       </div>
     </div>
   );

--- a/front/src/types/server.ts
+++ b/front/src/types/server.ts
@@ -1,3 +1,4 @@
+// 맵 컴포넌트 타입
 export interface ServerMapTypes {
   server: Phaser.Game | null;
   scene: Phaser.Scene | null;
@@ -24,4 +25,9 @@ export interface Layers {
   eggsLayer?: Phaser.Tilemaps.TilemapLayer | null;
   chickenLayer?: Phaser.Tilemaps.TilemapLayer | null;
   furnitureLayer?: Phaser.Tilemaps.TilemapLayer | null;
+}
+
+// 즐겨찾기 타입 지정
+export interface FavoritesState {
+  [key: string]: boolean;
 }

--- a/front/src/utils/fakeData.ts
+++ b/front/src/utils/fakeData.ts
@@ -2,7 +2,6 @@ export const serverData = [
   {
     serverId: "server1111",
     serverName: "server1",
-    category: "game",
     image:
       "https://images.unsplash.com/photo-1715276611440-6c0e90aa132b?q=80&w=2369&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
     members: ["민선님", "동근님"],
@@ -10,7 +9,6 @@ export const serverData = [
   {
     serverId: "server2222",
     serverName: "server2",
-    category: "education",
     image:
       "https://images.unsplash.com/photo-1715157163446-91abdd457a97?q=80&w=2487&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
     members: ["다원님", "동근님", "민아님"],
@@ -18,8 +16,6 @@ export const serverData = [
   {
     serverId: "server3333",
     serverName: "server3",
-    member: 13223,
-    category: "coding",
     image:
       "https://images.unsplash.com/photo-1461749280684-dccba630e2f6?q=80&w=2369&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
     members: ["다원님", "동근님", "민아님", "젼젼"],

--- a/front/src/utils/store.ts
+++ b/front/src/utils/store.ts
@@ -1,0 +1,19 @@
+import { create } from "zustand";
+
+interface FavoriteState {
+  favorites: Record<string, boolean>;
+  setFavorites: (id: string, isFavorite: boolean) => void;
+}
+
+const useStore = create<FavoriteState>()((set) => ({
+  favorites: {},
+  setFavorites: (id, isFavorite) =>
+    set((state) => ({
+      favorites: {
+        ...state.favorites,
+        [id]: isFavorite,
+      },
+    })),
+}));
+
+export default useStore;


### PR DESCRIPTION
## #️⃣연관된 이슈
None

## 📝작업 내용

1. 홈화면에 즐겨찾기된 서버들만 필터링해서 card UI 추가
2. zustand로 즐겨찾기된 서버 전역관리

### 스크린샷 (선택)

None

## 💬리뷰 요구사항(선택)

None

