### PR TITLE
[Server] 서버 목록 조회 검색 조건 기능 추가

### DIFF
--- a/core/src/main/kotlin/kpring/core/server/dto/request/GetServerCondition.kt
+++ b/core/src/main/kotlin/kpring/core/server/dto/request/GetServerCondition.kt
@@ -1,0 +1,5 @@
+package kpring.core.server.dto.request
+
+data class GetServerCondition(
+  val serverIds: List<String>? = null,
+)

--- a/server/src/main/kotlin/kpring/server/adapter/input/rest/RestApiServerController.kt
+++ b/server/src/main/kotlin/kpring/server/adapter/input/rest/RestApiServerController.kt
@@ -6,6 +6,7 @@ import kpring.core.server.dto.ServerInfo
 import kpring.core.server.dto.ServerSimpleInfo
 import kpring.core.server.dto.request.AddUserAtServerRequest
 import kpring.core.server.dto.request.CreateServerRequest
+import kpring.core.server.dto.request.GetServerCondition
 import kpring.server.application.port.input.AddUserAtServerUseCase
 import kpring.server.application.port.input.CreateServerUseCase
 import kpring.server.application.port.input.GetServerInfoUseCase
@@ -31,12 +32,13 @@ class RestApiServerController(
       .body(ApiResponse(data = data))
   }
 
-  @GetMapping()
+  @GetMapping
   fun getServerList(
     @RequestHeader("Authorization") token: String,
+    @ModelAttribute condition: GetServerCondition,
   ): ResponseEntity<ApiResponse<List<ServerSimpleInfo>>> {
     val userInfo = authClient.getTokenInfo(token).data!!
-    val data = getServerUseCase.getServerList(userInfo.userId)
+    val data = getServerUseCase.getServerList(condition, userInfo.userId)
     return ResponseEntity.ok()
       .body(ApiResponse(data = data))
   }

--- a/server/src/main/kotlin/kpring/server/adapter/output/mongo/GetServerProfileMongoImpl.kt
+++ b/server/src/main/kotlin/kpring/server/adapter/output/mongo/GetServerProfileMongoImpl.kt
@@ -2,6 +2,7 @@ package kpring.server.adapter.output.mongo
 
 import kpring.core.global.exception.CommonErrorCode
 import kpring.core.global.exception.ServiceException
+import kpring.core.server.dto.request.GetServerCondition
 import kpring.server.adapter.output.mongo.entity.QServerEntity
 import kpring.server.adapter.output.mongo.entity.QServerProfileEntity
 import kpring.server.adapter.output.mongo.repository.ServerProfileRepository
@@ -44,7 +45,10 @@ class GetServerProfileMongoImpl(
     return serverProfile
   }
 
-  override fun getProfiles(userId: String): List<ServerProfile> {
+  override fun getProfiles(
+    condition: GetServerCondition,
+    userId: String,
+  ): List<ServerProfile> {
     // get server profile
     val qProfile = QServerProfileEntity.serverProfileEntity
     val serverProfileEntities =

--- a/server/src/main/kotlin/kpring/server/application/port/input/GetServerInfoUseCase.kt
+++ b/server/src/main/kotlin/kpring/server/application/port/input/GetServerInfoUseCase.kt
@@ -2,9 +2,13 @@ package kpring.server.application.port.input
 
 import kpring.core.server.dto.ServerInfo
 import kpring.core.server.dto.ServerSimpleInfo
+import kpring.core.server.dto.request.GetServerCondition
 
 interface GetServerInfoUseCase {
   fun getServerInfo(serverId: String): ServerInfo
 
-  fun getServerList(userId: String): List<ServerSimpleInfo>
+  fun getServerList(
+    condition: GetServerCondition,
+    userId: String,
+  ): List<ServerSimpleInfo>
 }

--- a/server/src/main/kotlin/kpring/server/application/port/output/GetServerProfilePort.kt
+++ b/server/src/main/kotlin/kpring/server/application/port/output/GetServerProfilePort.kt
@@ -1,5 +1,6 @@
 package kpring.server.application.port.output
 
+import kpring.core.server.dto.request.GetServerCondition
 import kpring.server.domain.ServerProfile
 
 interface GetServerProfilePort {
@@ -8,7 +9,10 @@ interface GetServerProfilePort {
     userId: String,
   ): ServerProfile
 
-  fun getProfiles(userId: String): List<ServerProfile>
+  fun getProfiles(
+    condition: GetServerCondition,
+    userId: String,
+  ): List<ServerProfile>
 
   fun getAll(serverId: String): List<ServerProfile>
 }

--- a/server/src/main/kotlin/kpring/server/application/service/ServerService.kt
+++ b/server/src/main/kotlin/kpring/server/application/service/ServerService.kt
@@ -7,6 +7,7 @@ import kpring.core.server.dto.ServerSimpleInfo
 import kpring.core.server.dto.ServerUserInfo
 import kpring.core.server.dto.request.AddUserAtServerRequest
 import kpring.core.server.dto.request.CreateServerRequest
+import kpring.core.server.dto.request.GetServerCondition
 import kpring.core.server.dto.response.CreateServerResponse
 import kpring.server.application.port.input.AddUserAtServerUseCase
 import kpring.server.application.port.input.CreateServerUseCase
@@ -54,8 +55,11 @@ class ServerService(
     )
   }
 
-  override fun getServerList(userId: String): List<ServerSimpleInfo> {
-    return getServerProfilePort.getProfiles(userId)
+  override fun getServerList(
+    condition: GetServerCondition,
+    userId: String,
+  ): List<ServerSimpleInfo> {
+    return getServerProfilePort.getProfiles(condition, userId)
       .map { profile ->
         ServerSimpleInfo(
           id = profile.server.id,

--- a/server/src/test/kotlin/kpring/server/application/port/output/GetServerProfilePortTest.kt
+++ b/server/src/test/kotlin/kpring/server/application/port/output/GetServerProfilePortTest.kt
@@ -1,0 +1,60 @@
+package kpring.server.application.port.output
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import kpring.core.server.dto.request.GetServerCondition
+import kpring.server.adapter.output.mongo.entity.ServerEntity
+import kpring.server.adapter.output.mongo.entity.ServerProfileEntity
+import kpring.server.adapter.output.mongo.repository.ServerProfileRepository
+import kpring.server.adapter.output.mongo.repository.ServerRepository
+import kpring.server.domain.ServerRole
+import kpring.test.testcontainer.SpringTestContext
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ContextConfiguration
+
+@SpringBootTest
+@ContextConfiguration(initializers = [SpringTestContext.SpringDataMongo::class])
+class GetServerProfilePortTest(
+  val getServerProfilePort: GetServerProfilePort,
+  val serverRepository: ServerRepository,
+  val serverProfileRepository: ServerProfileRepository,
+) : DescribeSpec({
+
+    describe("서버 프로필 조회") {
+
+      it("제한된 서버 프로필을 조회하는 조건을 사용한다면 모든 프로필을 조회하지 않고 조건에 해당하는 서버 프로필만을 조회한다.") {
+        // given
+        val userIds = mutableListOf("testUserId")
+
+        val serverEntity1 =
+          serverRepository.save(
+            ServerEntity(name = "test", users = userIds),
+          )
+
+        val serverEntity2 =
+          serverRepository.save(
+            ServerEntity(name = "test", users = userIds),
+          )
+
+        val serverProfileEntity =
+          serverProfileRepository.save(
+            ServerProfileEntity(
+              serverId = serverEntity1.id,
+              userId = "testUserId",
+              name = "test",
+              imagePath = "test",
+              role = ServerRole.MEMBER,
+              bookmarked = false,
+            ),
+          )
+
+        val condition = GetServerCondition(serverIds = listOf(serverEntity1.id))
+
+        // when
+        val serverProfiles = getServerProfilePort.getProfiles(condition, userIds[0])
+
+        // then
+        serverProfiles shouldHaveSize 1
+      }
+    }
+  })

--- a/test/src/main/kotlin/kpring/test/web/URLBuilder.kt
+++ b/test/src/main/kotlin/kpring/test/web/URLBuilder.kt
@@ -1,0 +1,36 @@
+package kpring.test.web
+
+class URLBuilder(
+  private val url: String,
+) {
+  private val attributes: MutableList<Pair<String, String>> = mutableListOf()
+
+  fun query(
+    name: String,
+    value: String,
+  ): URLBuilder {
+    attributes.add(name to value)
+    return this
+  }
+
+  fun query(
+    name: String,
+    values: List<Any>,
+  ): URLBuilder {
+    return query(name, *values.toTypedArray())
+  }
+
+  fun query(
+    name: String,
+    vararg values: Any,
+  ): URLBuilder {
+    for (value in values) {
+      attributes.add(name to value.toString())
+    }
+    return this
+  }
+
+  fun build(): String {
+    return url + attributes.joinToString("&", "?") { (name, value) -> "$name=$value" }
+  }
+}

--- a/test/src/test/kotlin/test/web/URLBuilderTest.kt
+++ b/test/src/test/kotlin/test/web/URLBuilderTest.kt
@@ -1,0 +1,28 @@
+package test.web
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kpring.test.web.URLBuilder
+
+class URLBuilderTest : FunSpec({
+
+  test("make url with url builder") {
+    // given
+    val url = "http://localhost:8080"
+    val name = "test"
+    val value1 = "value1"
+    val value2 = "value2"
+    val values = listOf("value3", "value4")
+
+    // when
+    val finalURL =
+      URLBuilder(url)
+        .query(name, value1)
+        .query(name, value2)
+        .query(name, *values.toTypedArray())
+        .build()
+
+    // then
+    finalURL shouldBe "$url?$name=$value1&$name=$value2&$name=${values[0]}&$name=${values[1]}"
+  }
+})


### PR DESCRIPTION
## #️⃣연관된 이슈

- #123

## 📝작업 내용

- 서버 목록 조회시 조건을 추가하여 #123 이슈에 필요한 데이터만을 조회할 수 있도록 조건을 추가하였습니다.
- controller 테스트에서 query param를 입력하기 위한 test util 클래스를 생성하였습니다.
### 추가된 조건
- serverIds : 조건을 입력하면 입력한 서버 id 목록에 존재하는 서버 정보를 반환합니다.