### PR TITLE
[Test] request part object 문서화를 위한 custom dsl 기능 추가

### DIFF
--- a/test/src/main/kotlin/kpring/test/restdoc/dsl/RestDocMultipartFieldBuilder.kt
+++ b/test/src/main/kotlin/kpring/test/restdoc/dsl/RestDocMultipartFieldBuilder.kt
@@ -1,0 +1,20 @@
+package kpring.test.restdoc.dsl
+
+import org.springframework.restdocs.payload.FieldDescriptor
+import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+
+class RestDocMultipartFieldBuilder {
+  val fieldDescriptors = mutableListOf<FieldDescriptor>()
+
+  infix fun String.type(type: Any): FieldDescriptor = fieldWithPath(this).type(type)
+
+  infix fun FieldDescriptor.mean(description: String) {
+    fieldDescriptors.add(this.description(description))
+  }
+
+  infix fun String.mean(description: String): FieldDescriptor {
+    val descriptor: FieldDescriptor = fieldWithPath(this).description(description)
+    fieldDescriptors.add(descriptor)
+    return descriptor
+  }
+}

--- a/test/src/main/kotlin/kpring/test/restdoc/dsl/RestDocRequestBuilder.kt
+++ b/test/src/main/kotlin/kpring/test/restdoc/dsl/RestDocRequestBuilder.kt
@@ -2,6 +2,8 @@ package kpring.test.restdoc.dsl
 
 import org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders
 import org.springframework.restdocs.payload.PayloadDocumentation.requestFields
+import org.springframework.restdocs.payload.PayloadDocumentation.requestPartFields
+import org.springframework.restdocs.payload.RequestPartFieldsSnippet
 import org.springframework.restdocs.request.RequestDocumentation
 import org.springframework.restdocs.snippet.Snippet
 
@@ -46,6 +48,16 @@ class RestDocRequestBuilder {
     if (builder.partDescriptors.isNotEmpty()) {
       snippets.add(RequestDocumentation.requestParts(*builder.partDescriptors.toTypedArray()))
     }
+  }
+
+  fun part(
+    name: String,
+    config: RestDocMultipartFieldBuilder.() -> Unit,
+  ) {
+    val builder = RestDocMultipartFieldBuilder()
+    builder.config()
+    val descriptor: RequestPartFieldsSnippet = requestPartFields(name, *builder.fieldDescriptors.toTypedArray())
+    snippets.add(descriptor)
   }
 
   fun snippet(snippet: Snippet) {


### PR DESCRIPTION
## #️⃣연관된 이슈

- #127

## 📝작업 내용

request part에 object를 담았을 때 세부 사항에 대한 문서화 기능을 제공하지 않았습니다.
때문에 이 기능을 제공하도록 커스텀 dsl을 확장하였습니다.
