### PR TITLE
Feat/auth 회원가입 페이지의 Mui Alert와 이메일 중복 에러메세지 구현

### DIFF
--- a/front/src/components/Auth/JoinBox.tsx
+++ b/front/src/components/Auth/JoinBox.tsx
@@ -1,11 +1,17 @@
 import LoginIcon from "@mui/icons-material/Login";
 import PersonAddAlt1Icon from "@mui/icons-material/PersonAddAlt1";
+import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import Snackbar, { SnackbarCloseReason } from "@mui/material/Snackbar";
 import TextField from "@mui/material/TextField";
 import axios from "axios";
+import React, { SyntheticEvent, useState } from "react";
 import { useNavigate } from "react-router";
 import { JoinValidation } from "../../hooks/JoinValidation";
+
+import type { AlertInfo } from "../../types/join";
+
 function JoinBox() {
   const {
     values,
@@ -18,7 +24,13 @@ function JoinBox() {
     validatePasswordConfirm,
     validators,
   } = JoinValidation();
+  const [open, setOpen] = useState(false);
+  const [alertInfo, setAlertInfo] = useState<AlertInfo>({
+    severity: "info",
+    message: "",
+  });
 
+  const navigate = useNavigate();
   const onChangeHandler = (
     field: string,
     event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -45,8 +57,16 @@ function JoinBox() {
       );
 
       // 회원가입 성공
-      alert("회원가입 성공!");
+      setAlertInfo({
+        severity: "success",
+        message: "회원가입 성공! 3초 후 로그인 페이지로 이동합니다.",
+      });
+      setOpen(true);
+      setValues({ nickname: "", email: "", password: "", passwordConfirm: "" });
       console.log("회원가입 성공:", response.data);
+      setTimeout(() => {
+        navigate("/login");
+      }, 3000);
 
       // 입력 폼 초기화
       setValues({
@@ -57,12 +77,17 @@ function JoinBox() {
       });
     } catch (error) {
       if (axios.isAxiosError(error) && error.response) {
-        alert(`Error: ${error.response.data.message}`);
-        console.log("회원가입 오류:", error.response.data);
+        setAlertInfo({
+          severity: "error",
+          message: `Error: ${error.response.data.message}`,
+        });
       } else {
-        alert("회원가입 과정에서 문제가 발생했습니다.");
-        console.log("회원가입 중 예상치 못한 오류 발생", error);
+        setAlertInfo({
+          severity: "error",
+          message: "회원가입 과정에서 문제가 발생했습니다.",
+        });
       }
+      setOpen(true);
     }
   };
 
@@ -95,6 +120,16 @@ function JoinBox() {
         submitJoin();
       }
     }, 0);
+  };
+
+  const clickCloseHandler = (
+    event: Event | SyntheticEvent<any, Event>,
+    reason?: SnackbarCloseReason
+  ) => {
+    if (reason === "clickaway") {
+      return;
+    }
+    setOpen(false);
   };
 
   const navigation = useNavigate();
@@ -192,6 +227,19 @@ function JoinBox() {
             </Button>
           </div>
         </Box>
+        <Snackbar
+          open={open}
+          autoHideDuration={6000}
+          onClose={clickCloseHandler}
+        >
+          <Alert
+            onClose={clickCloseHandler}
+            severity={alertInfo.severity}
+            sx={{ width: "100%" }}
+          >
+            {alertInfo.message}
+          </Alert>
+        </Snackbar>
       </div>
     </section>
   );

--- a/front/src/components/Auth/JoinBox.tsx
+++ b/front/src/components/Auth/JoinBox.tsx
@@ -77,10 +77,14 @@ function JoinBox() {
       });
     } catch (error) {
       if (axios.isAxiosError(error) && error.response) {
-        setAlertInfo({
-          severity: "error",
-          message: `Error: ${error.response.data.message}`,
-        });
+        let errorMessage = "회원가입 과정에서 문제가 발생했습니다.";
+        if (error.response.data.message === "Email already exists") {
+          errorMessage = "이미 존재하는 이메일입니다. 다시 시도해주세요.";
+        } else {
+          errorMessage = error.response.data.message || errorMessage;
+        }
+
+        setAlertInfo({ severity: "error", message: errorMessage });
       } else {
         setAlertInfo({
           severity: "error",

--- a/front/src/types/join.ts
+++ b/front/src/types/join.ts
@@ -15,3 +15,8 @@ export type JoinBoxValidateErrors = {
 export interface Validators {
   [key: string]: (input: string) => string;
 }
+
+export interface AlertInfo {
+  severity: "success" | "info" | "warning" | "error";
+  message: string;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> 없음

## 📝작업 내용

### 1. 회원가입 페이지에서 회원가입 성공일때와 실패일 경우 alert를 Mui Alert로 변경
- 현재 사용중인 UI 라이브러리인 Mui의 alert를 구현했습니다.

1) 회원가입 성공인 경우
- 3초 후 자동으로 로그인 페이지로 이동합니다.
![image](https://github.com/kSideProject/kpring/assets/143374855/6e04b33f-06d5-4739-a410-e7b4747d5f0d)

2) 회원가입 실패인 경우
![image](https://github.com/kSideProject/kpring/assets/143374855/b8ef7f4d-8180-4585-8a0b-521a11010693)


### 2. 회원가입시 오류 메세지 중에서 이메일 중복 에러 메세지 구현
**- 커밋 메세지나 위의 제목이 적당한것을 찾지 못해서 일단 적었습니다만.. **
- 쉽게 말해서 이미 사용중인 이메일의 경우 아래처럼 알림이 뜹니다. 
- 구현 원리는 이미 사용중인 이메일을 입력하면 서버로부터 "Email already exists" 메세지가 오는데, 그 텍스트를 기반으로 "이미 존재하는 이메일입니다. 다시 시도해주세요."로 변경되도록 했습니다. 
![image](https://github.com/kSideProject/kpring/assets/143374855/c1182384-d641-4573-81a8-964f6b7952eb)


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
- Swagger UI를 봤는데.. 프론트 단에서 이메일이 빈칸인 경우 회원가입이 불가능하도록 해서 일단 에러 메세지는.. 이메일 중복에 대한 에러만 처리해뒀는데 별도의 또 다른 에러가 있을까요?  현재는 이메일 중복을 제외한 모든 오류는 "회원가입 과정에서 문제가 발생했습니다."로 처리해두었습니다.

♣ 참조한 Mui alert : https://mui.com/material-ui/react-alert/