### PR TITLE
[Infra] image registry 변경 

### DIFF
--- a/auth/build.gradle.kts
+++ b/auth/build.gradle.kts
@@ -84,7 +84,7 @@ jib {
     image = "eclipse-temurin:21-jre"
   }
   to {
-    image = "localhost:5000/auth-application"
+    image = "youdong98/kpring-auth-application"
     setAllowInsecureRegistries(true)
     tags = setOf("latest")
   }

--- a/infra/charts/auth/values.yaml
+++ b/infra/charts/auth/values.yaml
@@ -1,7 +1,7 @@
 # auth service
 service:
   name: auth-application
-  image: localhost:5000/auth-application:latest
+  image: youdong98/kpring-auth-application:latest
   port: 8080
   nodePort: 30001
   jwt:

--- a/infra/charts/server/values.yaml
+++ b/infra/charts/server/values.yaml
@@ -1,7 +1,7 @@
 # server service
 service:
   name: server-application
-  image: localhost:5000/server-application:latest
+  image: youdong98/kpring-server-application:latest
   port: 8080
   nodePort: 30003
 

--- a/infra/charts/user/values.yaml
+++ b/infra/charts/user/values.yaml
@@ -1,7 +1,7 @@
 # user service
 service:
   name: user-application
-  image: localhost:5000/user-application:latest
+  image: youdong98/kpring-user-application:latest
   port: 8080
   nodePort: 30002
 

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -81,7 +81,7 @@ jib {
     image = "eclipse-temurin:21-jre"
   }
   to {
-    image = "localhost:5000/server-application"
+    image = "youdong98/kpring-server-application"
     setAllowInsecureRegistries(true)
     tags = setOf("latest")
   }

--- a/user/build.gradle.kts
+++ b/user/build.gradle.kts
@@ -65,7 +65,7 @@ jib {
     image = "eclipse-temurin:21-jre"
   }
   to {
-    image = "localhost:5000/user-application"
+    image = "youdong98/kpring-user-application"
     setAllowInsecureRegistries(true)
     tags = setOf("latest")
   }


### PR DESCRIPTION
## 📝작업 내용

- image registry로 docker hub를 이용하도록 하여 빌드 과정을 단축시켰습니다.
- `./gradlew jib` 과정을 이제는 하지 않아도 어플리케이션을 배포할 수 있습니다.

## 🔗 참고
[이미지 저장 목록](https://hub.docker.com/repositories/youdong98)