### PR TITLE
[Server] 카테고리 조회 API 구현

### DIFF
--- a/core/src/main/kotlin/kpring/core/server/dto/CategoryInfo.kt
+++ b/core/src/main/kotlin/kpring/core/server/dto/CategoryInfo.kt
@@ -1,0 +1,5 @@
+package kpring.core.server.dto
+
+data class CategoryInfo(
+  val name: String,
+)

--- a/core/src/main/kotlin/kpring/core/server/dto/CategoryInfo.kt
+++ b/core/src/main/kotlin/kpring/core/server/dto/CategoryInfo.kt
@@ -1,5 +1,6 @@
 package kpring.core.server.dto
 
 data class CategoryInfo(
+  val id: String,
   val name: String,
 )

--- a/server/src/main/kotlin/kpring/server/adapter/input/rest/CategoryController.kt
+++ b/server/src/main/kotlin/kpring/server/adapter/input/rest/CategoryController.kt
@@ -1,0 +1,23 @@
+package kpring.server.adapter.input.rest
+
+import kpring.core.global.dto.response.ApiResponse
+import kpring.core.server.dto.CategoryInfo
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/category")
+class CategoryController() {
+  @GetMapping("")
+  fun getCategories(): ResponseEntity<ApiResponse<*>> {
+    val response =
+      listOf(
+        CategoryInfo("카테고리1"),
+        CategoryInfo("카테고리2"),
+      )
+    return ResponseEntity.ok()
+      .body(ApiResponse(data = response))
+  }
+}

--- a/server/src/main/kotlin/kpring/server/adapter/input/rest/CategoryController.kt
+++ b/server/src/main/kotlin/kpring/server/adapter/input/rest/CategoryController.kt
@@ -1,7 +1,7 @@
 package kpring.server.adapter.input.rest
 
 import kpring.core.global.dto.response.ApiResponse
-import kpring.core.server.dto.CategoryInfo
+import kpring.server.application.port.input.GetCategoryUseCase
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -9,14 +9,12 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/v1/category")
-class CategoryController() {
+class CategoryController(
+  val getCategoryUseCase: GetCategoryUseCase,
+) {
   @GetMapping("")
   fun getCategories(): ResponseEntity<ApiResponse<*>> {
-    val response =
-      listOf(
-        CategoryInfo("카테고리1"),
-        CategoryInfo("카테고리2"),
-      )
+    val response = getCategoryUseCase.getCategories()
     return ResponseEntity.ok()
       .body(ApiResponse(data = response))
   }

--- a/server/src/main/kotlin/kpring/server/application/port/input/GetCategoryUseCase.kt
+++ b/server/src/main/kotlin/kpring/server/application/port/input/GetCategoryUseCase.kt
@@ -1,0 +1,7 @@
+package kpring.server.application.port.input
+
+import kpring.core.server.dto.CategoryInfo
+
+interface GetCategoryUseCase {
+  fun getCategories(): List<CategoryInfo>
+}

--- a/server/src/main/kotlin/kpring/server/application/service/CategoryService.kt
+++ b/server/src/main/kotlin/kpring/server/application/service/CategoryService.kt
@@ -1,0 +1,18 @@
+package kpring.server.application.service
+
+import kpring.core.server.dto.CategoryInfo
+import kpring.server.application.port.input.GetCategoryUseCase
+import kpring.server.domain.Category
+import org.springframework.stereotype.Service
+
+@Service
+class CategoryService : GetCategoryUseCase {
+  override fun getCategories(): List<CategoryInfo> {
+    return Category.entries.map { category ->
+      CategoryInfo(
+        id = category.name,
+        name = category.toString(),
+      )
+    }
+  }
+}

--- a/server/src/main/kotlin/kpring/server/domain/Category.kt
+++ b/server/src/main/kotlin/kpring/server/domain/Category.kt
@@ -1,0 +1,13 @@
+package kpring.server.domain
+
+enum class Category(
+  private val toString: String,
+) {
+  SERVER_CATEGORY1("학습"),
+  SERVER_CATEGORY2("운동"),
+  ;
+
+  override fun toString(): String {
+    return toString
+  }
+}

--- a/server/src/main/kotlin/kpring/server/domain/Category.kt
+++ b/server/src/main/kotlin/kpring/server/domain/Category.kt
@@ -1,5 +1,9 @@
 package kpring.server.domain
 
+/**
+ * 2024-06-11 기준으로 카테고리와 관련된 기능이 없기 때문에 하드 코딩된 제한적인 카테고리를 사용합니다.
+ * 카테고리의 기능이 확장된다면 해당 클래스는 deprecated 처리되며 해당 정보는 DB에서 관리될 예정입니다.
+ */
 enum class Category(
   private val toString: String,
 ) {

--- a/server/src/test/kotlin/kpring/server/adapter/input/rest/CategoryControllerTest.kt
+++ b/server/src/test/kotlin/kpring/server/adapter/input/rest/CategoryControllerTest.kt
@@ -1,0 +1,6 @@
+package kpring.server.adapter.input.rest
+
+import io.kotest.core.spec.style.DescribeSpec
+
+class CategoryControllerTest : DescribeSpec({
+})

--- a/server/src/test/kotlin/kpring/server/adapter/input/rest/CategoryControllerTest.kt
+++ b/server/src/test/kotlin/kpring/server/adapter/input/rest/CategoryControllerTest.kt
@@ -2,10 +2,12 @@ package kpring.server.adapter.input.rest
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
 import io.mockk.junit5.MockKExtension
 import kpring.core.auth.client.AuthClient
 import kpring.core.global.dto.response.ApiResponse
 import kpring.core.server.dto.CategoryInfo
+import kpring.server.application.service.CategoryService
 import kpring.server.application.service.ServerService
 import kpring.server.config.CoreConfiguration
 import kpring.test.restdoc.dsl.restDoc
@@ -32,6 +34,7 @@ class CategoryControllerTest(
   webContext: WebApplicationContext,
   @MockkBean val serverService: ServerService,
   @MockkBean val authClient: AuthClient,
+  @MockkBean val categoryService: CategoryService,
 ) : MvcWebTestClientDescribeSpec(
     "Rest api server category controller test",
     webContext,
@@ -41,9 +44,16 @@ class CategoryControllerTest(
           // given
           val data =
             listOf(
-              CategoryInfo("카테고리1"),
-              CategoryInfo("카테고리2"),
+              CategoryInfo(
+                id = "SERVER_CATEGORY_1",
+                name = "category1",
+              ),
+              CategoryInfo(
+                id = "SERVER_CATEGORY_2",
+                name = "category2",
+              ),
             )
+          every { categoryService.getCategories() } returns data
           // when
           val result =
             client.get()

--- a/server/src/test/kotlin/kpring/server/adapter/input/rest/CategoryControllerTest.kt
+++ b/server/src/test/kotlin/kpring/server/adapter/input/rest/CategoryControllerTest.kt
@@ -1,6 +1,68 @@
 package kpring.server.adapter.input.rest
 
-import io.kotest.core.spec.style.DescribeSpec
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.junit5.MockKExtension
+import kpring.core.auth.client.AuthClient
+import kpring.core.global.dto.response.ApiResponse
+import kpring.core.server.dto.CategoryInfo
+import kpring.server.application.service.ServerService
+import kpring.server.config.CoreConfiguration
+import kpring.test.restdoc.dsl.restDoc
+import kpring.test.web.MvcWebTestClientDescribeSpec
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.web.context.WebApplicationContext
 
-class CategoryControllerTest : DescribeSpec({
-})
+@Import(CoreConfiguration::class)
+@WebMvcTest(
+  controllers = [
+    RestApiServerController::class,
+    CategoryController::class,
+  ],
+)
+@ExtendWith(
+  value = [
+    MockKExtension::class,
+  ],
+)
+class CategoryControllerTest(
+  private val om: ObjectMapper,
+  webContext: WebApplicationContext,
+  @MockkBean val serverService: ServerService,
+  @MockkBean val authClient: AuthClient,
+) : MvcWebTestClientDescribeSpec(
+    "Rest api server category controller test",
+    webContext,
+    { client ->
+      describe("GET /api/v1/category") {
+        it("200 : 성공 케이스") {
+          // given
+          val data =
+            listOf(
+              CategoryInfo("카테고리1"),
+              CategoryInfo("카테고리2"),
+            )
+          // when
+          val result =
+            client.get()
+              .uri("/api/v1/category")
+              .exchange()
+
+          // then
+          val docs =
+            result
+              .expectStatus().isOk
+              .expectBody().json(om.writeValueAsString(ApiResponse(data = data)))
+
+          // docs
+          docs.restDoc(
+            identifier = "get-categories",
+            description = "서버 카테고리 목록 조회",
+          ) {
+          }
+        }
+      }
+    },
+  )

--- a/server/src/test/kotlin/kpring/server/adapter/input/rest/RestApiServerControllerTest.kt
+++ b/server/src/test/kotlin/kpring/server/adapter/input/rest/RestApiServerControllerTest.kt
@@ -18,6 +18,7 @@ import kpring.core.server.dto.request.AddUserAtServerRequest
 import kpring.core.server.dto.request.CreateServerRequest
 import kpring.core.server.dto.request.GetServerCondition
 import kpring.core.server.dto.response.CreateServerResponse
+import kpring.server.application.service.CategoryService
 import kpring.server.application.service.ServerService
 import kpring.server.config.CoreConfiguration
 import kpring.test.restdoc.dsl.restDoc
@@ -46,6 +47,7 @@ class RestApiServerControllerTest(
   webContext: WebApplicationContext,
   @MockkBean val serverService: ServerService,
   @MockkBean val authClient: AuthClient,
+  @MockkBean val categoryService: CategoryService,
 ) : MvcWebTestClientDescribeSpec(
     testMethodName = "RestApiServerControllerTest",
     webContext = webContext,

--- a/server/src/test/kotlin/kpring/server/adapter/input/rest/RestApiServerControllerTest.kt
+++ b/server/src/test/kotlin/kpring/server/adapter/input/rest/RestApiServerControllerTest.kt
@@ -22,8 +22,8 @@ import kpring.server.application.service.ServerService
 import kpring.server.config.CoreConfiguration
 import kpring.test.restdoc.dsl.restDoc
 import kpring.test.restdoc.json.JsonDataType.*
+import kpring.test.web.MvcWebTestClientDescribeSpec
 import kpring.test.web.URLBuilder
-import kpring.test.web.WebTestClientDescribeSpec
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.Import
@@ -41,7 +41,7 @@ class RestApiServerControllerTest(
   webContext: WebApplicationContext,
   @MockkBean val serverService: ServerService,
   @MockkBean val authClient: AuthClient,
-) : WebTestClientDescribeSpec(
+) : MvcWebTestClientDescribeSpec(
     testMethodName = "RestApiServerControllerTest",
     webContext = webContext,
     body = { client ->

--- a/server/src/test/kotlin/kpring/server/adapter/input/rest/RestApiServerControllerTest.kt
+++ b/server/src/test/kotlin/kpring/server/adapter/input/rest/RestApiServerControllerTest.kt
@@ -2,7 +2,6 @@ package kpring.server.adapter.input.rest
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
-import io.kotest.core.spec.style.DescribeSpec
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.junit5.MockKExtension
@@ -24,13 +23,10 @@ import kpring.server.config.CoreConfiguration
 import kpring.test.restdoc.dsl.restDoc
 import kpring.test.restdoc.json.JsonDataType.*
 import kpring.test.web.URLBuilder
+import kpring.test.web.WebTestClientDescribeSpec
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.Import
-import org.springframework.restdocs.ManualRestDocumentation
-import org.springframework.restdocs.operation.preprocess.Preprocessors
-import org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation
-import org.springframework.test.web.servlet.client.MockMvcWebTestClient
 import org.springframework.web.context.WebApplicationContext
 
 @Import(CoreConfiguration::class)
@@ -45,338 +41,326 @@ class RestApiServerControllerTest(
   webContext: WebApplicationContext,
   @MockkBean val serverService: ServerService,
   @MockkBean val authClient: AuthClient,
-) : DescribeSpec({
+) : WebTestClientDescribeSpec(
+    testMethodName = "RestApiServerControllerTest",
+    webContext = webContext,
+    body = { client ->
 
-    val restDocument = ManualRestDocumentation()
-    val webTestClient =
-      MockMvcWebTestClient.bindToApplicationContext(webContext)
-        .configureClient()
-        .filter(
-          WebTestClientRestDocumentation.documentationConfiguration(restDocument)
-            .operationPreprocessors()
-            .withRequestDefaults(Preprocessors.prettyPrint())
-            .withResponseDefaults(Preprocessors.prettyPrint()),
-        )
-        .build()
+      afterTest { clearMocks(authClient) }
 
-    beforeSpec { restDocument.beforeTest(this.javaClass, "user controller") }
+      describe("POST /api/v1/server : createServer api test") {
+        val url = "/api/v1/server"
+        it("요청 성공시") {
+          // given
+          val request = CreateServerRequest(serverName = "test server")
+          val data = CreateServerResponse(serverId = "1", serverName = request.serverName)
 
-    afterSpec { restDocument.afterTest() }
-
-    afterTest { clearMocks(authClient) }
-
-    describe("POST /api/v1/server : createServer api test") {
-      val url = "/api/v1/server"
-      it("요청 성공시") {
-        // given
-        val request = CreateServerRequest(serverName = "test server")
-        val data = CreateServerResponse(serverId = "1", serverName = request.serverName)
-
-        every { authClient.getTokenInfo(any()) } returns
-          ApiResponse(
-            data =
-              TokenInfo(
-                type = TokenType.ACCESS,
-                userId = "test_user_id",
-              ),
-          )
-        every { serverService.createServer(eq(request), any()) } returns data
-
-        // when
-        val result =
-          webTestClient.post()
-            .uri(url)
-            .header("Authorization", "Bearer mock_token")
-            .bodyValue(request)
-            .exchange()
-
-        // then
-        val docs =
-          result
-            .expectStatus().isOk
-            .expectBody()
-            .json(om.writeValueAsString(ApiResponse(data = data)))
-
-        // docs
-        docs.restDoc(
-          identifier = "create_server_200",
-          description = "서버 생성 api",
-        ) {
-          request {
-            header { "Authorization" mean "jwt access token" }
-            body {
-              "serverName" type Strings mean "생성할 서버의 이름"
-            }
-          }
-
-          response {
-            body {
-              "data.serverId" type Strings mean "서버 id"
-              "data.serverName" type Strings mean "생성된 서버 이름"
-            }
-          }
-        }
-      }
-    }
-
-    describe("GET /api/v1/server/{serverId}: 서버 조회 api test") {
-
-      val url = "/api/v1/server/{serverId}"
-      it("요청 성공시") {
-        // given
-        val serverId = "test_server_id"
-        val data = ServerInfo(id = serverId, name = "test_server", users = emptyList())
-        every { serverService.getServerInfo(serverId) } returns data
-
-        // when
-        val result =
-          webTestClient.get()
-            .uri(url, serverId)
-            .exchange()
-
-        // then
-        val docs =
-          result
-            .expectStatus().isOk
-            .expectBody()
-            .json(om.writeValueAsString(ApiResponse(data = data)))
-
-        // docs
-        docs.restDoc(
-          identifier = "get_server_info_200",
-          description = "서버 단건 조회 api",
-        ) {
-          request {
-            path { "serverId" mean "서버 id" }
-          }
-
-          response {
-            body {
-              "data.id" type Strings mean "서버 id"
-              "data.name" type Strings mean "생성된 서버 이름"
-              "data.users" type Arrays mean "서버에 가입된 유저 목록"
-            }
-          }
-        }
-      }
-
-      it("요청 실패 : 존재하지 않은 서버") {
-        // given
-        val serverId = "not_exist_server_id"
-        val errorCode = CommonErrorCode.NOT_FOUND
-        every { serverService.getServerInfo(serverId) } throws ServiceException(errorCode)
-
-        // when
-        val result =
-          webTestClient.get()
-            .uri(url, serverId)
-            .exchange()
-
-        // then
-        val docs =
-          result
-            .expectStatus().isNotFound
-            .expectBody()
-            .json(om.writeValueAsString(ApiResponse<Any>(message = errorCode.message())))
-
-        // docs
-        docs.restDoc(
-          identifier = "get_server_info_with_invalid_id",
-          description = "서버 단건 조회 api",
-        ) {
-          request {
-            path { "serverId" mean "서버 id" }
-          }
-
-          response {
-            body {
-              "message" type Strings mean "실패 관련 메시지"
-            }
-          }
-        }
-      }
-    }
-
-    describe("PUT /api/v1/server/{serverId}/user : 서버 가입 api test") {
-      val url = "/api/v1/server/{serverId}/user"
-      it("요청 성공시") {
-        // given
-        val request =
-          AddUserAtServerRequest(userId = "userId", userName = "test", profileImage = "test")
-        justRun { serverService.addInvitedUser("test_server_id", request) }
-
-        // when
-        val result =
-          webTestClient.put()
-            .uri(url, "test_server_id")
-            .header("Authorization", "Bearer mock_token")
-            .bodyValue(request)
-            .exchange()
-
-        // then
-        val docs =
-          result
-            .expectStatus().isOk
-            .expectBody()
-
-        // docs
-        docs.restDoc(
-          identifier = "add_invited_user_200",
-          description = "서버 가입 api",
-        ) {
-          request {
-            header { "Authorization" mean "jwt access token" }
-            path { "serverId" mean "서버 id" }
-            body {
-              "userId" type Strings mean "가입할 유저 id"
-              "userName" type Strings mean "가입할 유저 이름"
-              "profileImage" type Strings mean "가입할 유저 프로필 이미지"
-            }
-          }
-        }
-      }
-    }
-
-    describe("PUT /api/v1/server/{serverId}/invitation/{userId} : 서버 초대 api test") {
-      val url = "/api/v1/server/{serverId}/invitation/{userId}"
-      it("요청 성공시") {
-        // given
-        every { authClient.getTokenInfo(any()) } returns
-          ApiResponse(
-            data =
-              TokenInfo(
-                type = TokenType.ACCESS,
-                userId = "test_user_id",
-              ),
-          )
-        justRun { serverService.inviteUser(eq("test_server_id"), any(), any()) }
-
-        // when
-        val result =
-          webTestClient.put()
-            .uri(url, "test_server_id", "userId")
-            .header("Authorization", "Bearer mock_token")
-            .exchange()
-
-        // then
-        val docs =
-          result
-            .expectStatus().isOk
-            .expectBody()
-
-        // docs
-        docs.restDoc(
-          identifier = "invite_user_200",
-          description = "서버 초대 api",
-        ) {
-          request {
-            header { "Authorization" mean "jwt access token" }
-            path {
-              "serverId" mean "서버 id"
-              "userId" mean "초대할 유저 id"
-            }
-          }
-        }
-      }
-    }
-
-    describe("GET /api/v1/server: 서버 목록 조회 api test") {
-
-      val url = "/api/v1/server"
-      it("요청 성공시") {
-        // given
-        val userId = "test user id"
-        val data =
-          listOf(
-            ServerSimpleInfo(id = "server1", name = "test_server", bookmarked = false),
-            ServerSimpleInfo(id = "server2", name = "test_server", bookmarked = true),
-          )
-        val condition = GetServerCondition(serverIds = listOf("server1", "server2"))
-
-        every { authClient.getTokenInfo(any()) } returns
-          ApiResponse(
-            data = TokenInfo(TokenType.ACCESS, userId),
-          )
-        every { serverService.getServerList(any(), eq(userId)) } returns data
-
-        // when
-        val result =
-          webTestClient.get()
-            .uri(
-              URLBuilder(url)
-                .query("serverIds", condition.serverIds!!)
-                .build(),
+          every { authClient.getTokenInfo(any()) } returns
+            ApiResponse(
+              data =
+                TokenInfo(
+                  type = TokenType.ACCESS,
+                  userId = "test_user_id",
+                ),
             )
-            .header("Authorization", "Bearer test_token")
-            .exchange()
+          every { serverService.createServer(eq(request), any()) } returns data
 
-        // then
-        val docs =
-          result
-            .expectStatus().isOk
-            .expectBody()
-            .json(om.writeValueAsString(ApiResponse(data = data)))
+          // when
+          val result =
+            client.post()
+              .uri(url)
+              .header("Authorization", "Bearer mock_token")
+              .bodyValue(request)
+              .exchange()
 
-        // docs
-        docs.restDoc(
-          identifier = "get_server_list_info_200",
-          description = "서버 목록 조회 api",
-        ) {
-          request {
-            query { "serverIds" mean "조회시 해당 서버 목록만을 조회합니다. 값이 없다면 조건은 적용되지 않습니다." }
-            header { "Authorization" mean "jwt access token" }
-          }
+          // then
+          val docs =
+            result
+              .expectStatus().isOk
+              .expectBody()
+              .json(om.writeValueAsString(ApiResponse(data = data)))
 
-          response {
-            body {
-              "data[].id" type Strings mean "서버 id"
-              "data[].name" type Strings mean "서버 이름"
-              "data[].bookmarked" type Booleans mean "북마크 여부"
+          // docs
+          docs.restDoc(
+            identifier = "create_server_200",
+            description = "서버 생성 api",
+          ) {
+            request {
+              header { "Authorization" mean "jwt access token" }
+              body {
+                "serverName" type Strings mean "생성할 서버의 이름"
+              }
+            }
+
+            response {
+              body {
+                "data.serverId" type Strings mean "서버 id"
+                "data.serverName" type Strings mean "생성된 서버 이름"
+              }
             }
           }
         }
       }
-    }
 
-    describe("DELETE /api/v1/server/{serverId} : 서버 삭제") {
-      val url = "/api/v1/server/{serverId}"
-      it("요청 성공시") {
-        // given
-        val serverId = "test_server_id"
-        val token = "Bearer mock_token"
-        every { authClient.getTokenInfo(token) } returns
-          ApiResponse(
-            data =
-              TokenInfo(
-                type = TokenType.ACCESS,
-                userId = "test_user_id",
-              ),
-          )
-        justRun { serverService.deleteServer(eq(serverId), any()) }
+      describe("GET /api/v1/server/{serverId}: 서버 조회 api test") {
 
-        // when
-        val result =
-          webTestClient.delete()
-            .uri(url, serverId)
-            .header("Authorization", token)
-            .exchange()
+        val url = "/api/v1/server/{serverId}"
+        it("요청 성공시") {
+          // given
+          val serverId = "test_server_id"
+          val data = ServerInfo(id = serverId, name = "test_server", users = emptyList())
+          every { serverService.getServerInfo(serverId) } returns data
 
-        // then
-        val docs =
-          result
-            .expectStatus().isOk
-            .expectBody()
+          // when
+          val result =
+            client.get()
+              .uri(url, serverId)
+              .exchange()
 
-        // docs
-        docs.restDoc(
-          identifier = "delete_server_200",
-          description = "서버 삭제 api",
-        ) {
-          request {
-            header { "Authorization" mean "jwt 사용자 토큰" }
-            path { "serverId" mean "서버 id" }
+          // then
+          val docs =
+            result
+              .expectStatus().isOk
+              .expectBody()
+              .json(om.writeValueAsString(ApiResponse(data = data)))
+
+          // docs
+          docs.restDoc(
+            identifier = "get_server_info_200",
+            description = "서버 단건 조회 api",
+          ) {
+            request {
+              path { "serverId" mean "서버 id" }
+            }
+
+            response {
+              body {
+                "data.id" type Strings mean "서버 id"
+                "data.name" type Strings mean "생성된 서버 이름"
+                "data.users" type Arrays mean "서버에 가입된 유저 목록"
+              }
+            }
+          }
+        }
+
+        it("요청 실패 : 존재하지 않은 서버") {
+          // given
+          val serverId = "not_exist_server_id"
+          val errorCode = CommonErrorCode.NOT_FOUND
+          every { serverService.getServerInfo(serverId) } throws ServiceException(errorCode)
+
+          // when
+          val result =
+            client.get()
+              .uri(url, serverId)
+              .exchange()
+
+          // then
+          val docs =
+            result
+              .expectStatus().isNotFound
+              .expectBody()
+              .json(om.writeValueAsString(ApiResponse<Any>(message = errorCode.message())))
+
+          // docs
+          docs.restDoc(
+            identifier = "get_server_info_with_invalid_id",
+            description = "서버 단건 조회 api",
+          ) {
+            request {
+              path { "serverId" mean "서버 id" }
+            }
+
+            response {
+              body {
+                "message" type Strings mean "실패 관련 메시지"
+              }
+            }
           }
         }
       }
-    }
-  })
+
+      describe("PUT /api/v1/server/{serverId}/user : 서버 가입 api test") {
+        val url = "/api/v1/server/{serverId}/user"
+        it("요청 성공시") {
+          // given
+          val request =
+            AddUserAtServerRequest(userId = "userId", userName = "test", profileImage = "test")
+          justRun { serverService.addInvitedUser("test_server_id", request) }
+
+          // when
+          val result =
+            client.put()
+              .uri(url, "test_server_id")
+              .header("Authorization", "Bearer mock_token")
+              .bodyValue(request)
+              .exchange()
+
+          // then
+          val docs =
+            result
+              .expectStatus().isOk
+              .expectBody()
+
+          // docs
+          docs.restDoc(
+            identifier = "add_invited_user_200",
+            description = "서버 가입 api",
+          ) {
+            request {
+              header { "Authorization" mean "jwt access token" }
+              path { "serverId" mean "서버 id" }
+              body {
+                "userId" type Strings mean "가입할 유저 id"
+                "userName" type Strings mean "가입할 유저 이름"
+                "profileImage" type Strings mean "가입할 유저 프로필 이미지"
+              }
+            }
+          }
+        }
+      }
+
+      describe("PUT /api/v1/server/{serverId}/invitation/{userId} : 서버 초대 api test") {
+        val url = "/api/v1/server/{serverId}/invitation/{userId}"
+        it("요청 성공시") {
+          // given
+          every { authClient.getTokenInfo(any()) } returns
+            ApiResponse(
+              data =
+                TokenInfo(
+                  type = TokenType.ACCESS,
+                  userId = "test_user_id",
+                ),
+            )
+          justRun { serverService.inviteUser(eq("test_server_id"), any(), any()) }
+
+          // when
+          val result =
+            client.put()
+              .uri(url, "test_server_id", "userId")
+              .header("Authorization", "Bearer mock_token")
+              .exchange()
+
+          // then
+          val docs =
+            result
+              .expectStatus().isOk
+              .expectBody()
+
+          // docs
+          docs.restDoc(
+            identifier = "invite_user_200",
+            description = "서버 초대 api",
+          ) {
+            request {
+              header { "Authorization" mean "jwt access token" }
+              path {
+                "serverId" mean "서버 id"
+                "userId" mean "초대할 유저 id"
+              }
+            }
+          }
+        }
+      }
+
+      describe("GET /api/v1/server: 서버 목록 조회 api test") {
+
+        val url = "/api/v1/server"
+        it("요청 성공시") {
+          // given
+          val userId = "test user id"
+          val data =
+            listOf(
+              ServerSimpleInfo(id = "server1", name = "test_server", bookmarked = false),
+              ServerSimpleInfo(id = "server2", name = "test_server", bookmarked = true),
+            )
+          val condition = GetServerCondition(serverIds = listOf("server1", "server2"))
+
+          every { authClient.getTokenInfo(any()) } returns
+            ApiResponse(
+              data = TokenInfo(TokenType.ACCESS, userId),
+            )
+          every { serverService.getServerList(any(), eq(userId)) } returns data
+
+          // when
+          val result =
+            client.get()
+              .uri(
+                URLBuilder(url)
+                  .query("serverIds", condition.serverIds!!)
+                  .build(),
+              )
+              .header("Authorization", "Bearer test_token")
+              .exchange()
+
+          // then
+          val docs =
+            result
+              .expectStatus().isOk
+              .expectBody()
+              .json(om.writeValueAsString(ApiResponse(data = data)))
+
+          // docs
+          docs.restDoc(
+            identifier = "get_server_list_info_200",
+            description = "서버 목록 조회 api",
+          ) {
+            request {
+              query { "serverIds" mean "조회시 해당 서버 목록만을 조회합니다. 값이 없다면 조건은 적용되지 않습니다." }
+              header { "Authorization" mean "jwt access token" }
+            }
+
+            response {
+              body {
+                "data[].id" type Strings mean "서버 id"
+                "data[].name" type Strings mean "서버 이름"
+                "data[].bookmarked" type Booleans mean "북마크 여부"
+              }
+            }
+          }
+        }
+      }
+
+      describe("DELETE /api/v1/server/{serverId} : 서버 삭제") {
+        val url = "/api/v1/server/{serverId}"
+        it("요청 성공시") {
+          // given
+          val serverId = "test_server_id"
+          val token = "Bearer mock_token"
+          every { authClient.getTokenInfo(token) } returns
+            ApiResponse(
+              data =
+                TokenInfo(
+                  type = TokenType.ACCESS,
+                  userId = "test_user_id",
+                ),
+            )
+          justRun { serverService.deleteServer(eq(serverId), any()) }
+
+          // when
+          val result =
+            client.delete()
+              .uri(url, serverId)
+              .header("Authorization", token)
+              .exchange()
+
+          // then
+          val docs =
+            result
+              .expectStatus().isOk
+              .expectBody()
+
+          // docs
+          docs.restDoc(
+            identifier = "delete_server_200",
+            description = "서버 삭제 api",
+          ) {
+            request {
+              header { "Authorization" mean "jwt 사용자 토큰" }
+              path { "serverId" mean "서버 id" }
+            }
+          }
+        }
+      }
+    },
+  )

--- a/server/src/test/kotlin/kpring/server/adapter/input/rest/RestApiServerControllerTest.kt
+++ b/server/src/test/kotlin/kpring/server/adapter/input/rest/RestApiServerControllerTest.kt
@@ -30,7 +30,12 @@ import org.springframework.context.annotation.Import
 import org.springframework.web.context.WebApplicationContext
 
 @Import(CoreConfiguration::class)
-@WebMvcTest(controllers = [RestApiServerController::class])
+@WebMvcTest(
+  controllers = [
+    RestApiServerController::class,
+    CategoryController::class,
+  ],
+)
 @ExtendWith(
   value = [
     MockKExtension::class,

--- a/server/src/test/kotlin/kpring/server/application/service/CategoryServiceTest.kt
+++ b/server/src/test/kotlin/kpring/server/application/service/CategoryServiceTest.kt
@@ -1,0 +1,25 @@
+package kpring.server.application.service
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kpring.core.server.dto.CategoryInfo
+import kpring.server.domain.Category
+
+class CategoryServiceTest : FunSpec({
+
+  test("카테고리 목록 조회시 하드 코딩된 카테고리 정보를 조회한다.") {
+    // given
+    val categoryService = CategoryService()
+
+    // when
+    val categories = categoryService.getCategories()
+
+    // then
+    categories shouldBe
+      listOf(
+        CategoryInfo(id = Category.SERVER_CATEGORY1.name, name = Category.SERVER_CATEGORY1.toString()),
+        CategoryInfo(id = Category.SERVER_CATEGORY2.name, name = Category.SERVER_CATEGORY2.toString()),
+      )
+    println(categories)
+  }
+})

--- a/test/src/main/kotlin/kpring/test/web/MvcWebTestClientDescribeSpec.kt
+++ b/test/src/main/kotlin/kpring/test/web/MvcWebTestClientDescribeSpec.kt
@@ -8,7 +8,7 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.servlet.client.MockMvcWebTestClient
 import org.springframework.web.context.WebApplicationContext
 
-open class WebTestClientDescribeSpec(
+open class MvcWebTestClientDescribeSpec(
   testMethodName: String,
   webContext: WebApplicationContext,
   body: DescribeSpec.(webTestClient: WebTestClient) -> Unit = {},

--- a/test/src/main/kotlin/kpring/test/web/MvcWebTestClientDescribeSpec.kt
+++ b/test/src/main/kotlin/kpring/test/web/MvcWebTestClientDescribeSpec.kt
@@ -8,7 +8,7 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.servlet.client.MockMvcWebTestClient
 import org.springframework.web.context.WebApplicationContext
 
-open class MvcWebTestClientDescribeSpec(
+abstract class MvcWebTestClientDescribeSpec(
   testMethodName: String,
   webContext: WebApplicationContext,
   body: DescribeSpec.(webTestClient: WebTestClient) -> Unit = {},

--- a/test/src/main/kotlin/kpring/test/web/WebTestClientDescribeSpec.kt
+++ b/test/src/main/kotlin/kpring/test/web/WebTestClientDescribeSpec.kt
@@ -1,0 +1,34 @@
+package kpring.test.web
+
+import io.kotest.core.spec.style.DescribeSpec
+import org.springframework.restdocs.ManualRestDocumentation
+import org.springframework.restdocs.operation.preprocess.Preprocessors
+import org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.servlet.client.MockMvcWebTestClient
+import org.springframework.web.context.WebApplicationContext
+
+open class WebTestClientDescribeSpec(
+  testMethodName: String,
+  webContext: WebApplicationContext,
+  body: DescribeSpec.(webTestClient: WebTestClient) -> Unit = {},
+) : DescribeSpec({
+
+    val restDocument = ManualRestDocumentation()
+
+    val webTestClient: WebTestClient =
+      MockMvcWebTestClient.bindToApplicationContext(webContext)
+        .configureClient()
+        .filter(
+          WebTestClientRestDocumentation.documentationConfiguration(restDocument)
+            .operationPreprocessors()
+            .withRequestDefaults(Preprocessors.prettyPrint())
+            .withResponseDefaults(Preprocessors.prettyPrint()),
+        )
+        .build()
+
+    beforeSpec { restDocument.beforeTest(this.javaClass, testMethodName) }
+    afterSpec { restDocument.afterTest() }
+
+    body(webTestClient)
+  })


### PR DESCRIPTION
## #️⃣연관된 이슈

- #159 

## 📝작업 내용

서버의 카테고리 기능이 추가되면서 카테고리 목록조회에 대한 기능을 구현하였습니다.
카테고리 기능을 활용하는 추가적인 기능이 없기 때문에 하드코딩한 카테고리 목록을 사용하는 방식으로 구현하였습니다.
