### PR TITLE
[Server] 서버 생성 : 테마, 카테고리 입력 확장

### DIFF
--- a/core/src/main/kotlin/kpring/core/server/dto/ServerThemeInfo.kt
+++ b/core/src/main/kotlin/kpring/core/server/dto/ServerThemeInfo.kt
@@ -1,0 +1,6 @@
+package kpring.core.server.dto
+
+data class ServerThemeInfo(
+  val id: String,
+  val name: String,
+)

--- a/core/src/main/kotlin/kpring/core/server/dto/request/CreateServerRequest.kt
+++ b/core/src/main/kotlin/kpring/core/server/dto/request/CreateServerRequest.kt
@@ -2,4 +2,7 @@ package kpring.core.server.dto.request
 
 data class CreateServerRequest(
   val serverName: String,
+  val userId: String,
+  val theme: String? = null,
+  val categories: List<String> = listOf(),
 )

--- a/core/src/main/kotlin/kpring/core/server/dto/request/CreateServerRequest.kt
+++ b/core/src/main/kotlin/kpring/core/server/dto/request/CreateServerRequest.kt
@@ -4,5 +4,5 @@ data class CreateServerRequest(
   val serverName: String,
   val userId: String,
   val theme: String? = null,
-  val categories: List<String> = listOf(),
+  val categories: List<String>? = null,
 )

--- a/core/src/main/kotlin/kpring/core/server/dto/response/CreateServerResponse.kt
+++ b/core/src/main/kotlin/kpring/core/server/dto/response/CreateServerResponse.kt
@@ -1,6 +1,11 @@
 package kpring.core.server.dto.response
 
+import kpring.core.server.dto.CategoryInfo
+import kpring.core.server.dto.ServerThemeInfo
+
 data class CreateServerResponse(
   val serverId: String,
   val serverName: String,
+  val theme: ServerThemeInfo,
+  val categories: List<CategoryInfo>,
 )

--- a/server/src/main/kotlin/kpring/server/adapter/input/rest/RestApiServerController.kt
+++ b/server/src/main/kotlin/kpring/server/adapter/input/rest/RestApiServerController.kt
@@ -38,7 +38,7 @@ class RestApiServerController(
     }
 
     // logic
-    val data = createServerUseCase.createServer(request, userInfo.userId)
+    val data = createServerUseCase.createServer(request)
 
     return ResponseEntity.ok()
       .body(ApiResponse(data = data))

--- a/server/src/main/kotlin/kpring/server/adapter/input/rest/RestApiServerController.kt
+++ b/server/src/main/kotlin/kpring/server/adapter/input/rest/RestApiServerController.kt
@@ -27,9 +27,19 @@ class RestApiServerController(
   fun createServer(
     @RequestHeader("Authorization") token: String,
     @RequestBody request: CreateServerRequest,
-  ): ResponseEntity<ApiResponse<*>> {
+  ): ResponseEntity<ApiResponse<Any>> {
+    // get and validate user token
     val userInfo = authClient.getTokenInfo(token).data!!
+
+    // validate userId
+    if (userInfo.userId != request.userId) {
+      return ResponseEntity.badRequest()
+        .body(ApiResponse(message = "유저 정보가 일치하지 않습니다"))
+    }
+
+    // logic
     val data = createServerUseCase.createServer(request, userInfo.userId)
+
     return ResponseEntity.ok()
       .body(ApiResponse(data = data))
   }

--- a/server/src/main/kotlin/kpring/server/adapter/output/mongo/GetServerPortMongoImpl.kt
+++ b/server/src/main/kotlin/kpring/server/adapter/output/mongo/GetServerPortMongoImpl.kt
@@ -3,6 +3,7 @@ package kpring.server.adapter.output.mongo
 import kpring.core.global.exception.CommonErrorCode
 import kpring.core.global.exception.ServiceException
 import kpring.server.adapter.output.mongo.entity.QServerEntity
+import kpring.server.adapter.output.mongo.entity.ServerEntity
 import kpring.server.adapter.output.mongo.repository.ServerRepository
 import kpring.server.application.port.output.GetServerPort
 import kpring.server.domain.Server
@@ -17,12 +18,7 @@ class GetServerPortMongoImpl(
       serverRepository.findById(id)
         .orElseThrow { throw ServiceException(CommonErrorCode.NOT_FOUND) }
 
-    return Server(
-      id = serverEntity.id,
-      name = serverEntity.name,
-      users = serverEntity.users.toMutableSet(),
-      invitedUserIds = serverEntity.invitedUserIds.toMutableSet(),
-    )
+    return serverEntity.toDomain()
   }
 
   override fun getServerWith(userId: String): List<Server> {
@@ -32,13 +28,6 @@ class GetServerPortMongoImpl(
         server.users.any().eq(userId),
       )
 
-    return servers.map { entity ->
-      Server(
-        id = entity.id,
-        name = entity.name,
-        users = entity.users.toMutableSet(),
-        invitedUserIds = entity.invitedUserIds.toMutableSet(),
-      )
-    }
+    return servers.map(ServerEntity::toDomain)
   }
 }

--- a/server/src/main/kotlin/kpring/server/adapter/output/mongo/GetServerProfileMongoImpl.kt
+++ b/server/src/main/kotlin/kpring/server/adapter/output/mongo/GetServerProfileMongoImpl.kt
@@ -36,6 +36,7 @@ class GetServerProfileMongoImpl(
     val server = serverEntity.toDomain()
     val serverProfile =
       ServerProfile(
+        id = serverProfileEntity.id,
         server = server,
         userId = serverProfileEntity.userId,
         name = serverProfileEntity.name,
@@ -60,7 +61,7 @@ class GetServerProfileMongoImpl(
     // get server
     val targetServerIds =
       serverProfileEntities
-        .map { it.serverId }
+        .map { it.serverId!! }
 
     val qServer = QServerEntity.serverEntity
 
@@ -76,6 +77,7 @@ class GetServerProfileMongoImpl(
       val serverEntity = serverMap[it.serverId]!!
       val server = serverEntity.toDomain()
       ServerProfile(
+        id = serverEntity.id,
         server = server,
         userId = it.userId,
         name = it.name,
@@ -97,6 +99,7 @@ class GetServerProfileMongoImpl(
 
     return serverProfileEntities.map {
       ServerProfile(
+        id = it.id,
         server = server,
         userId = it.userId,
         name = it.name,

--- a/server/src/main/kotlin/kpring/server/adapter/output/mongo/SaveServerPortMongoImpl.kt
+++ b/server/src/main/kotlin/kpring/server/adapter/output/mongo/SaveServerPortMongoImpl.kt
@@ -1,12 +1,15 @@
 package kpring.server.adapter.output.mongo
 
 import kpring.server.adapter.output.mongo.entity.ServerEntity
+import kpring.server.adapter.output.mongo.entity.ServerProfileEntity
 import kpring.server.adapter.output.mongo.repository.ServerProfileRepository
 import kpring.server.adapter.output.mongo.repository.ServerRepository
 import kpring.server.application.port.output.SaveServerPort
 import kpring.server.domain.Server
+import kpring.server.domain.ServerRole
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Repository
+import java.util.*
 
 @Repository
 class SaveServerPortMongoImpl(
@@ -20,19 +23,20 @@ class SaveServerPortMongoImpl(
     // create server
     val serverEntity = serverRepository.save(ServerEntity(server))
 
-//    // create owner server profile
-//    serverProfileRepository.save(
-//      ServerProfileEntity(
-//        userId = req.userId,
-//        // todo change
-//        name = "USER_${UUID.randomUUID()}",
-//        // todo change
-//        imagePath = defaultImagePath,
-//        serverId = serverEntity.id,
-//        role = ServerRole.OWNER,
-//        bookmarked = false,
-//      ),
-//    )
+    // create owner server profile
+    serverProfileRepository.save(
+      ServerProfileEntity(
+        id = null,
+        userId = server.users.first(),
+        // todo change
+        name = "USER_${UUID.randomUUID()}",
+        // todo change
+        imagePath = defaultImagePath,
+        serverId = serverEntity.id,
+        role = ServerRole.OWNER,
+        bookmarked = false,
+      ),
+    )
 
     // mapping
     return serverEntity.toDomain()

--- a/server/src/main/kotlin/kpring/server/adapter/output/mongo/SaveServerPortMongoImpl.kt
+++ b/server/src/main/kotlin/kpring/server/adapter/output/mongo/SaveServerPortMongoImpl.kt
@@ -1,16 +1,12 @@
 package kpring.server.adapter.output.mongo
 
-import kpring.core.server.dto.request.CreateServerRequest
 import kpring.server.adapter.output.mongo.entity.ServerEntity
-import kpring.server.adapter.output.mongo.entity.ServerProfileEntity
 import kpring.server.adapter.output.mongo.repository.ServerProfileRepository
 import kpring.server.adapter.output.mongo.repository.ServerRepository
 import kpring.server.application.port.output.SaveServerPort
 import kpring.server.domain.Server
-import kpring.server.domain.ServerRole
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Repository
-import java.util.*
 
 @Repository
 class SaveServerPortMongoImpl(
@@ -20,30 +16,25 @@ class SaveServerPortMongoImpl(
   @Value("\${resource.default.profileImagePath}")
   private lateinit var defaultImagePath: String
 
-  override fun create(req: CreateServerRequest): Server {
+  override fun create(server: Server): Server {
     // create server
-    val serverEntity =
-      serverRepository.save(ServerEntity(name = req.serverName))
+    val serverEntity = serverRepository.save(ServerEntity(server))
 
-    // create owner server profile
-    serverProfileRepository.save(
-      ServerProfileEntity(
-        userId = req.userId,
-        // todo change
-        name = "USER_${UUID.randomUUID()}",
-        // todo change
-        imagePath = defaultImagePath,
-        serverId = serverEntity.id,
-        role = ServerRole.OWNER,
-        bookmarked = false,
-      ),
-    )
+//    // create owner server profile
+//    serverProfileRepository.save(
+//      ServerProfileEntity(
+//        userId = req.userId,
+//        // todo change
+//        name = "USER_${UUID.randomUUID()}",
+//        // todo change
+//        imagePath = defaultImagePath,
+//        serverId = serverEntity.id,
+//        role = ServerRole.OWNER,
+//        bookmarked = false,
+//      ),
+//    )
 
     // mapping
-    return Server(
-      id = serverEntity.id,
-      name = serverEntity.name,
-      users = mutableSetOf(),
-    )
+    return serverEntity.toDomain()
   }
 }

--- a/server/src/main/kotlin/kpring/server/adapter/output/mongo/SaveServerPortMongoImpl.kt
+++ b/server/src/main/kotlin/kpring/server/adapter/output/mongo/SaveServerPortMongoImpl.kt
@@ -20,10 +20,7 @@ class SaveServerPortMongoImpl(
   @Value("\${resource.default.profileImagePath}")
   private lateinit var defaultImagePath: String
 
-  override fun create(
-    req: CreateServerRequest,
-    userId: String,
-  ): Server {
+  override fun create(req: CreateServerRequest): Server {
     // create server
     val serverEntity =
       serverRepository.save(ServerEntity(name = req.serverName))
@@ -31,7 +28,7 @@ class SaveServerPortMongoImpl(
     // create owner server profile
     serverProfileRepository.save(
       ServerProfileEntity(
-        userId = userId,
+        userId = req.userId,
         // todo change
         name = "USER_${UUID.randomUUID()}",
         // todo change

--- a/server/src/main/kotlin/kpring/server/adapter/output/mongo/entity/ServerEntity.kt
+++ b/server/src/main/kotlin/kpring/server/adapter/output/mongo/entity/ServerEntity.kt
@@ -1,14 +1,26 @@
 package kpring.server.adapter.output.mongo.entity
 
+import kpring.server.domain.Category
 import kpring.server.domain.Server
+import kpring.server.domain.Theme
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Document
 
+/**
+ * @property id MongoDB의 ID를 나타냅니다.
+ * @property name 서버의 이름을 나타냅니다.
+ * @property users 서버에 속한 사용자의 아이디를 나타냅니다. 더 상세한 서버 유저에 대한 정보는 [ServerProfileEntity] 에서 찾을 수 있습니다.
+ * @property invitedUserIds 서버에 구성원은 아니지만 서버에 초대된 사용자의 아이디를 나타냅니다. 초대된 사용자는 서버에 가입할 수 있는 권한을 얻게 됩니다.
+ * @property theme 서버의 테마 정보를 나타냅니다. 테마 정보를 입력하지 않는다면 디폴트 값이 설정되며 디폴트 값은 [Theme.default] 입니다.
+ * @property categories 서버의 카테고리 정보를 나타냅니다. 카테고리 정보를 입력하지 않는다면 카테고리가 없는 서버를 생성합니다.
+ */
 @Document(collection = "server")
 class ServerEntity(
   var name: String,
   var users: MutableList<String> = mutableListOf(),
   var invitedUserIds: MutableList<String> = mutableListOf(),
+  val theme: Theme = Theme.default(),
+  val categories: Set<Category> = emptySet(),
 ) {
   @Id
   lateinit var id: String

--- a/server/src/main/kotlin/kpring/server/adapter/output/mongo/entity/ServerEntity.kt
+++ b/server/src/main/kotlin/kpring/server/adapter/output/mongo/entity/ServerEntity.kt
@@ -16,21 +16,31 @@ import org.springframework.data.mongodb.core.mapping.Document
  */
 @Document(collection = "server")
 class ServerEntity(
-  var name: String,
-  var users: MutableList<String> = mutableListOf(),
-  var invitedUserIds: MutableList<String> = mutableListOf(),
-  val theme: Theme = Theme.default(),
-  val categories: Set<Category> = emptySet(),
-) {
   @Id
-  lateinit var id: String
+  val id: String?,
+  var name: String,
+  var users: MutableSet<String>,
+  var invitedUserIds: MutableSet<String>,
+  val theme: Theme,
+  val categories: Set<Category>,
+) {
+  constructor(server: Server) : this(
+    id = server.id,
+    name = server.name,
+    users = server.users,
+    invitedUserIds = server.invitedUserIds,
+    theme = server.theme,
+    categories = server.categories,
+  )
 
   fun toDomain(): Server {
     return Server(
       id = id,
       name = name,
-      users = users.toMutableSet(),
+      users = users,
       invitedUserIds = invitedUserIds.toMutableSet(),
+      theme = theme,
+      categories = categories,
     )
   }
 }

--- a/server/src/main/kotlin/kpring/server/adapter/output/mongo/entity/ServerProfileEntity.kt
+++ b/server/src/main/kotlin/kpring/server/adapter/output/mongo/entity/ServerProfileEntity.kt
@@ -1,18 +1,28 @@
 package kpring.server.adapter.output.mongo.entity
 
+import kpring.server.domain.ServerProfile
 import kpring.server.domain.ServerRole
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Document
 
 @Document("server_profile")
 class ServerProfileEntity(
+  @Id
+  val id: String?,
   val userId: String,
   val name: String,
   val imagePath: String,
-  val serverId: String,
+  val serverId: String?,
   val role: ServerRole,
   val bookmarked: Boolean,
 ) {
-  @Id
-  private var id: String? = null
+  constructor(profile: ServerProfile) : this(
+    id = profile.id,
+    userId = profile.userId,
+    name = profile.name,
+    imagePath = profile.imagePath,
+    serverId = profile.server.id,
+    role = profile.role,
+    bookmarked = profile.bookmarked,
+  )
 }

--- a/server/src/main/kotlin/kpring/server/application/port/input/CreateServerUseCase.kt
+++ b/server/src/main/kotlin/kpring/server/application/port/input/CreateServerUseCase.kt
@@ -4,8 +4,5 @@ import kpring.core.server.dto.request.CreateServerRequest
 import kpring.core.server.dto.response.CreateServerResponse
 
 interface CreateServerUseCase {
-  fun createServer(
-    req: CreateServerRequest,
-    userId: String,
-  ): CreateServerResponse
+  fun createServer(req: CreateServerRequest): CreateServerResponse
 }

--- a/server/src/main/kotlin/kpring/server/application/port/output/SaveServerPort.kt
+++ b/server/src/main/kotlin/kpring/server/application/port/output/SaveServerPort.kt
@@ -1,8 +1,7 @@
 package kpring.server.application.port.output
 
-import kpring.core.server.dto.request.CreateServerRequest
 import kpring.server.domain.Server
 
 interface SaveServerPort {
-  fun create(req: CreateServerRequest): Server
+  fun create(server: Server): Server
 }

--- a/server/src/main/kotlin/kpring/server/application/port/output/SaveServerPort.kt
+++ b/server/src/main/kotlin/kpring/server/application/port/output/SaveServerPort.kt
@@ -4,8 +4,5 @@ import kpring.core.server.dto.request.CreateServerRequest
 import kpring.server.domain.Server
 
 interface SaveServerPort {
-  fun create(
-    req: CreateServerRequest,
-    userId: String,
-  ): Server
+  fun create(req: CreateServerRequest): Server
 }

--- a/server/src/main/kotlin/kpring/server/application/service/ServerService.kt
+++ b/server/src/main/kotlin/kpring/server/application/service/ServerService.kt
@@ -30,10 +30,7 @@ class ServerService(
   val updateServerPort: UpdateServerPort,
   val deleteServerPort: DeleteServerPort,
 ) : CreateServerUseCase, GetServerInfoUseCase, AddUserAtServerUseCase, DeleteServerUseCase {
-  override fun createServer(
-    req: CreateServerRequest,
-    userId: String,
-  ): CreateServerResponse {
+  override fun createServer(req: CreateServerRequest): CreateServerResponse {
     val server = createServerPort.create(req)
     return CreateServerResponse(
       serverId = server.id,

--- a/server/src/main/kotlin/kpring/server/application/service/ServerService.kt
+++ b/server/src/main/kotlin/kpring/server/application/service/ServerService.kt
@@ -34,7 +34,7 @@ class ServerService(
     req: CreateServerRequest,
     userId: String,
   ): CreateServerResponse {
-    val server = createServerPort.create(req, userId)
+    val server = createServerPort.create(req)
     return CreateServerResponse(
       serverId = server.id,
       serverName = server.name,

--- a/server/src/main/kotlin/kpring/server/application/service/ServerService.kt
+++ b/server/src/main/kotlin/kpring/server/application/service/ServerService.kt
@@ -18,8 +18,10 @@ import kpring.server.application.port.output.GetServerPort
 import kpring.server.application.port.output.GetServerProfilePort
 import kpring.server.application.port.output.SaveServerPort
 import kpring.server.application.port.output.UpdateServerPort
+import kpring.server.domain.Category
 import kpring.server.domain.Server
 import kpring.server.domain.ServerAuthority
+import kpring.server.util.toInfo
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -44,6 +46,8 @@ class ServerService(
     return CreateServerResponse(
       serverId = server.id!!,
       serverName = server.name,
+      theme = server.theme.toInfo(),
+      categories = server.categories.map(Category::toInfo),
     )
   }
 

--- a/server/src/main/kotlin/kpring/server/domain/Server.kt
+++ b/server/src/main/kotlin/kpring/server/domain/Server.kt
@@ -4,13 +4,60 @@ import kpring.core.global.exception.ServiceException
 import kpring.server.error.ServerErrorCode
 
 class Server(
-  val id: String,
+  val id: String?,
   val name: String,
   val users: MutableSet<String> = mutableSetOf(),
   val invitedUserIds: MutableSet<String> = mutableSetOf(),
-  val theme: Theme = Theme.default(),
-  val categories: Set<Category> = emptySet(),
+  val theme: Theme,
+  val categories: Set<Category>,
 ) {
+  constructor(
+    name: String,
+    users: MutableSet<String> = mutableSetOf(),
+    invitedUserIds: MutableSet<String> = mutableSetOf(),
+    theme: String? = null,
+    categories: List<String>? = null,
+  ) : this(null, name, users, invitedUserIds, initTheme(theme), initCategories(categories))
+
+  companion object {
+    // -----------start : 초기화 로직 ------------
+
+    /**
+     * 서버의 테마 정보를 초기화합니다.
+     * @param theme 서버의 테마 id를 나타냅니다. 테마 정보를 입력하지 않는다면 디폴트 값이 설정되며 디폴트 값은 [Theme.default] 입니다.
+     * @throws ServiceException 요청한 테마 id가 잘못된 경우
+     */
+    private fun initTheme(theme: String?): Theme {
+      if (theme == null) {
+        return Theme.default()
+      }
+      try {
+        return Theme.valueOf(theme)
+      } catch (e: IllegalArgumentException) {
+        throw ServiceException(ServerErrorCode.INVALID_THEME_ID)
+      }
+    }
+
+    /**
+     * 서버의 카테고리 정보를 초기화합니다.
+     * @param categories 서버의 카테고리 id를 나타냅니다. 카테고리 정보를 입력하지 않는다면 카테고리가 없는 서버를 생성합니다.
+     * @throws ServiceException 요청한 카테고리 id가 잘못된 경우
+     */
+    private fun initCategories(categories: List<String>?): Set<Category> {
+      if (categories == null) {
+        return setOf()
+      }
+      return categories.map {
+        try {
+          Category.valueOf(it)
+        } catch (e: IllegalArgumentException) {
+          throw ServiceException(ServerErrorCode.INVALID_CATEGORY_ID)
+        }
+      }.toSet()
+    }
+    // -----------end : 초기화 로직 --------------
+  }
+
   private fun isInvited(userId: String): Boolean {
     return invitedUserIds.contains(userId)
   }
@@ -30,7 +77,7 @@ class Server(
     } else {
       throw ServiceException(ServerErrorCode.USER_NOT_INVITED)
     }
-    return ServerProfile(userId, name, imagePath, this)
+    return ServerProfile(null, userId, name, imagePath, this)
   }
 
   /**

--- a/server/src/main/kotlin/kpring/server/domain/Server.kt
+++ b/server/src/main/kotlin/kpring/server/domain/Server.kt
@@ -8,6 +8,8 @@ class Server(
   val name: String,
   val users: MutableSet<String> = mutableSetOf(),
   val invitedUserIds: MutableSet<String> = mutableSetOf(),
+  val theme: Theme = Theme.default(),
+  val categories: Set<Category> = emptySet(),
 ) {
   private fun isInvited(userId: String): Boolean {
     return invitedUserIds.contains(userId)

--- a/server/src/main/kotlin/kpring/server/domain/ServerProfile.kt
+++ b/server/src/main/kotlin/kpring/server/domain/ServerProfile.kt
@@ -1,6 +1,7 @@
 package kpring.server.domain
 
 class ServerProfile(
+  val id: String?,
   val userId: String,
   val name: String,
   val imagePath: String,

--- a/server/src/main/kotlin/kpring/server/domain/Theme.kt
+++ b/server/src/main/kotlin/kpring/server/domain/Theme.kt
@@ -1,0 +1,17 @@
+package kpring.server.domain
+
+enum class Theme(
+  val title: String,
+) {
+  SERVER_THEME_001("숲"),
+  SERVER_THEME_002("오피스"),
+  ;
+
+  companion object {
+    fun default() = SERVER_THEME_001
+  }
+
+  fun id(): String = this.name
+
+  fun displayName(): String = this.title
+}

--- a/server/src/main/kotlin/kpring/server/error/ServerErrorCode.kt
+++ b/server/src/main/kotlin/kpring/server/error/ServerErrorCode.kt
@@ -10,6 +10,8 @@ enum class ServerErrorCode(
 ) : ErrorCode {
   USER_NOT_INVITED("SERVER_001", "유저가 초대되지 않았습니다.", HttpStatus.FORBIDDEN),
   ALREADY_REGISTERED_USER("SERVER_002", "이미 등록된 유저입니다.", HttpStatus.BAD_REQUEST),
+  INVALID_THEME_ID("SERVER_003", "유효하지 않은 테마 아이디입니다.", HttpStatus.BAD_REQUEST),
+  INVALID_CATEGORY_ID("SERVER_004", "유효하지 않은 카테고리 아이디입니다.", HttpStatus.BAD_REQUEST),
   ;
 
   override fun id(): String = id

--- a/server/src/main/kotlin/kpring/server/util/DtoMapper.kt
+++ b/server/src/main/kotlin/kpring/server/util/DtoMapper.kt
@@ -1,0 +1,20 @@
+package kpring.server.util
+
+import kpring.core.server.dto.CategoryInfo
+import kpring.core.server.dto.ServerThemeInfo
+import kpring.server.domain.Category
+import kpring.server.domain.Theme
+
+fun Category.toInfo(): CategoryInfo  {
+  return CategoryInfo(
+    id = this.name,
+    name = this.toString(),
+  )
+}
+
+fun Theme.toInfo(): ServerThemeInfo {
+  return ServerThemeInfo(
+    id = this.id(),
+    name = this.displayName(),
+  )
+}

--- a/server/src/test/kotlin/kpring/server/adapter/input/rest/RestApiServerControllerTest.kt
+++ b/server/src/test/kotlin/kpring/server/adapter/input/rest/RestApiServerControllerTest.kt
@@ -72,7 +72,7 @@ class RestApiServerControllerTest(
                   userId = userId,
                 ),
             )
-          every { serverService.createServer(eq(request), any()) } returns data
+          every { serverService.createServer(eq(request)) } returns data
 
           // when
           val result =

--- a/server/src/test/kotlin/kpring/server/adapter/input/rest/RestApiServerControllerTest.kt
+++ b/server/src/test/kotlin/kpring/server/adapter/input/rest/RestApiServerControllerTest.kt
@@ -59,7 +59,9 @@ class RestApiServerControllerTest(
         val url = "/api/v1/server"
         it("요청 성공시") {
           // given
-          val request = CreateServerRequest(serverName = "test server")
+          val userId = "test_user_id"
+
+          val request = CreateServerRequest(serverName = "test server", userId = userId)
           val data = CreateServerResponse(serverId = "1", serverName = request.serverName)
 
           every { authClient.getTokenInfo(any()) } returns
@@ -67,7 +69,7 @@ class RestApiServerControllerTest(
               data =
                 TokenInfo(
                   type = TokenType.ACCESS,
-                  userId = "test_user_id",
+                  userId = userId,
                 ),
             )
           every { serverService.createServer(eq(request), any()) } returns data
@@ -96,6 +98,9 @@ class RestApiServerControllerTest(
               header { "Authorization" mean "jwt access token" }
               body {
                 "serverName" type Strings mean "생성할 서버의 이름"
+                "userId" type Strings mean "서버를 생성하는 유저의 id"
+                "theme" type Strings mean "생성할 서버의 테마" optional true
+                "categories" type Arrays mean "생성할 서버의 카테고리 목록" optional true
               }
             }
 

--- a/server/src/test/kotlin/kpring/server/adapter/input/rest/RestApiServerControllerTest.kt
+++ b/server/src/test/kotlin/kpring/server/adapter/input/rest/RestApiServerControllerTest.kt
@@ -21,6 +21,9 @@ import kpring.core.server.dto.response.CreateServerResponse
 import kpring.server.application.service.CategoryService
 import kpring.server.application.service.ServerService
 import kpring.server.config.CoreConfiguration
+import kpring.server.domain.Category
+import kpring.server.domain.Theme
+import kpring.server.util.toInfo
 import kpring.test.restdoc.dsl.restDoc
 import kpring.test.restdoc.json.JsonDataType.*
 import kpring.test.web.MvcWebTestClientDescribeSpec
@@ -62,7 +65,13 @@ class RestApiServerControllerTest(
           val userId = "test_user_id"
 
           val request = CreateServerRequest(serverName = "test server", userId = userId)
-          val data = CreateServerResponse(serverId = "1", serverName = request.serverName)
+          val data =
+            CreateServerResponse(
+              serverId = "1",
+              serverName = request.serverName,
+              theme = Theme.default().toInfo(),
+              categories = listOf(Category.SERVER_CATEGORY1, Category.SERVER_CATEGORY2).map(Category::toInfo),
+            )
 
           every { authClient.getTokenInfo(any()) } returns
             ApiResponse(
@@ -108,6 +117,12 @@ class RestApiServerControllerTest(
               body {
                 "data.serverId" type Strings mean "서버 id"
                 "data.serverName" type Strings mean "생성된 서버 이름"
+
+                "data.theme.id" type Strings mean "테마 id"
+                "data.theme.name" type Strings mean "테마 이름"
+
+                "data.categories[].id" type Strings mean "카테고리 id"
+                "data.categories[].name" type Strings mean "카테고리 이름"
               }
             }
           }
@@ -145,7 +160,7 @@ class RestApiServerControllerTest(
 
           // docs
           docs.restDoc(
-            identifier = "create_server_200",
+            identifier = "create_server_fail-400",
             description = "서버 생성 api",
           ) {
             request {

--- a/server/src/test/kotlin/kpring/server/application/port/input/AddUserAtServerUseCaseTest.kt
+++ b/server/src/test/kotlin/kpring/server/application/port/input/AddUserAtServerUseCaseTest.kt
@@ -28,9 +28,11 @@ class AddUserAtServerUseCaseTest(
       // given
       val invitorId = "invitorId"
       val userId = "userId"
-      val server = Server(id = "serverId", name = "serverName")
+      val serverId = "serverId"
+      val server = Server(name = "serverName")
       val serverProfile =
         ServerProfile(
+          id = null,
           userId = invitorId,
           name = "invitor",
           imagePath = "imagePath",
@@ -38,13 +40,13 @@ class AddUserAtServerUseCaseTest(
           server = server,
         )
 
-      every { getServerPort.get(server.id) } returns server
-      every { getServerProfilePort.get(server.id, invitorId) } returns serverProfile
+      every { getServerPort.get(serverId) } returns server
+      every { getServerProfilePort.get(serverId, invitorId) } returns serverProfile
 
       // when
       val ex =
         shouldThrow<ServiceException> {
-          service.inviteUser(server.id, invitorId, userId)
+          service.inviteUser(serverId, invitorId, userId)
         }
 
       // then

--- a/server/src/test/kotlin/kpring/server/application/port/input/DeleteServerUseCaseTest.kt
+++ b/server/src/test/kotlin/kpring/server/application/port/input/DeleteServerUseCaseTest.kt
@@ -29,11 +29,11 @@ class DeleteServerUseCaseTest(
       val userId = "userId"
       val server =
         Server(
-          id = serverId,
           name = "serverName",
         )
       val serverProfile =
         ServerProfile(
+          id = null,
           userId = userId,
           name = "name",
           imagePath = "/imagePath",

--- a/server/src/test/kotlin/kpring/server/application/port/output/GetServerPortTest.kt
+++ b/server/src/test/kotlin/kpring/server/application/port/output/GetServerPortTest.kt
@@ -9,6 +9,7 @@ import kpring.core.global.exception.CommonErrorCode
 import kpring.core.global.exception.ServiceException
 import kpring.server.adapter.output.mongo.entity.ServerEntity
 import kpring.server.adapter.output.mongo.repository.ServerRepository
+import kpring.server.domain.Server
 import kpring.test.testcontainer.SpringTestContext
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ContextConfiguration
@@ -35,14 +36,12 @@ class GetServerPortTest(
 
     it("저장된 서버의 정보를 조회할 수 있다.") {
       // given
-      val userIds = mutableListOf("id")
-      val serverEntity =
-        serverRepository.save(
-          ServerEntity(name = "test", users = userIds),
-        )
+      val userIds = mutableSetOf("id")
+      val domain = Server(name = "test", users = userIds)
+      val serverEntity = serverRepository.save(ServerEntity(domain))
 
       // when
-      val server = getServerPort.get(serverEntity.id)
+      val server = getServerPort.get(serverEntity.id!!)
 
       // then
       server.name shouldBe "test"
@@ -64,10 +63,11 @@ class GetServerPortTest(
     it("유저가 속한 서버 목록을 조회할 수 있다.") {
       // given
       val userId = "test-user"
-      val userIds = mutableListOf(userId)
+      val userIds = mutableSetOf(userId)
+      val server = Server(name = "server", users = userIds)
 
       repeat(2) {
-        serverRepository.save(ServerEntity(name = "test$it", users = userIds))
+        serverRepository.save(ServerEntity(server))
       }
 
       // when

--- a/server/src/test/kotlin/kpring/server/application/port/output/GetServerProfilePortTest.kt
+++ b/server/src/test/kotlin/kpring/server/application/port/output/GetServerProfilePortTest.kt
@@ -7,7 +7,10 @@ import kpring.server.adapter.output.mongo.entity.ServerEntity
 import kpring.server.adapter.output.mongo.entity.ServerProfileEntity
 import kpring.server.adapter.output.mongo.repository.ServerProfileRepository
 import kpring.server.adapter.output.mongo.repository.ServerRepository
+import kpring.server.domain.Server
+import kpring.server.domain.ServerProfile
 import kpring.server.domain.ServerRole
+import kpring.server.domain.Theme
 import kpring.test.testcontainer.SpringTestContext
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ContextConfiguration
@@ -24,34 +27,29 @@ class GetServerProfilePortTest(
 
       it("제한된 서버 프로필을 조회하는 조건을 사용한다면 모든 프로필을 조회하지 않고 조건에 해당하는 서버 프로필만을 조회한다.") {
         // given
-        val userIds = mutableListOf("testUserId")
+        val userIds = mutableSetOf("testUserId")
+        val server1 = Server(id = "testId", name = "test", users = userIds, theme = Theme.default(), categories = emptySet())
+        val server2 = Server(name = "test", users = userIds)
 
-        val serverEntity1 =
-          serverRepository.save(
-            ServerEntity(name = "test", users = userIds),
+        val serverEntity1 = serverRepository.save(ServerEntity(server1))
+        val serverEntity2 = serverRepository.save(ServerEntity(server2))
+
+        val server1Profile =
+          ServerProfile(
+            id = null,
+            userId = "testUserId",
+            name = "test",
+            imagePath = "test",
+            role = ServerRole.MEMBER,
+            server = server1,
           )
 
-        val serverEntity2 =
-          serverRepository.save(
-            ServerEntity(name = "test", users = userIds),
-          )
+        val serverProfileEntity = serverProfileRepository.save(ServerProfileEntity(server1Profile))
 
-        val serverProfileEntity =
-          serverProfileRepository.save(
-            ServerProfileEntity(
-              serverId = serverEntity1.id,
-              userId = "testUserId",
-              name = "test",
-              imagePath = "test",
-              role = ServerRole.MEMBER,
-              bookmarked = false,
-            ),
-          )
-
-        val condition = GetServerCondition(serverIds = listOf(serverEntity1.id))
+        val condition = GetServerCondition(serverIds = listOf(serverEntity1.id!!))
 
         // when
-        val serverProfiles = getServerProfilePort.getProfiles(condition, userIds[0])
+        val serverProfiles = getServerProfilePort.getProfiles(condition, "testUserId")
 
         // then
         serverProfiles shouldHaveSize 1

--- a/server/src/test/kotlin/kpring/server/application/port/output/SaveServerPortTest.kt
+++ b/server/src/test/kotlin/kpring/server/application/port/output/SaveServerPortTest.kt
@@ -18,7 +18,11 @@ class SaveServerPortTest(
     it("서버를 저장하면 생성한 유저는 서버의 소유자가 된다.") {
       // given
       val userId = "userId"
-      val req = CreateServerRequest(serverName = "serverName")
+      val req =
+        CreateServerRequest(
+          serverName = "serverName",
+          userId = userId,
+        )
 
       // when
       val server = saveServerPort.create(req, userId)

--- a/server/src/test/kotlin/kpring/server/application/port/output/SaveServerPortTest.kt
+++ b/server/src/test/kotlin/kpring/server/application/port/output/SaveServerPortTest.kt
@@ -2,7 +2,7 @@ package kpring.server.application.port.output
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
-import kpring.core.server.dto.request.CreateServerRequest
+import kpring.server.domain.Server
 import kpring.server.domain.ServerRole
 import kpring.test.testcontainer.SpringTestContext
 import org.springframework.boot.test.context.SpringBootTest
@@ -18,15 +18,11 @@ class SaveServerPortTest(
     it("서버를 저장하면 생성한 유저는 서버의 소유자가 된다.") {
       // given
       val userId = "userId"
-      val req =
-        CreateServerRequest(
-          serverName = "serverName",
-          userId = userId,
-        )
+      val domain = Server(name = "test", users = mutableSetOf(userId))
 
       // when
-      val server = saveServerPort.create(req)
-      val profile = getServerProfilePort.get(server.id, userId)
+      val server = saveServerPort.create(domain)
+      val profile = getServerProfilePort.get(server.id!!, userId)
 
       // then
       profile.role shouldBe ServerRole.OWNER

--- a/server/src/test/kotlin/kpring/server/application/port/output/SaveServerPortTest.kt
+++ b/server/src/test/kotlin/kpring/server/application/port/output/SaveServerPortTest.kt
@@ -25,7 +25,7 @@ class SaveServerPortTest(
         )
 
       // when
-      val server = saveServerPort.create(req, userId)
+      val server = saveServerPort.create(req)
       val profile = getServerProfilePort.get(server.id, userId)
 
       // then

--- a/server/src/test/kotlin/kpring/server/application/port/output/UpdateServerPortTest.kt
+++ b/server/src/test/kotlin/kpring/server/application/port/output/UpdateServerPortTest.kt
@@ -19,7 +19,7 @@ class UpdateServerPortTest(
     it("유저를 초대가 작동한다.") {
       // given
       val userId = "userId"
-      val server = createServerPort.create(CreateServerRequest("serverName"), userId)
+      val server = createServerPort.create(CreateServerRequest("serverName", userId), userId)
 
       // when
       repeat(5) {
@@ -34,7 +34,7 @@ class UpdateServerPortTest(
     it("가입 유저를 추가할 수 있다.") {
       // given
       val ownerId = "ownerId"
-      val server = createServerPort.create(CreateServerRequest("serverName"), ownerId)
+      val server = createServerPort.create(CreateServerRequest("serverName", ownerId), ownerId)
       val userId = "userId"
 
       server.registerInvitation(userId)

--- a/server/src/test/kotlin/kpring/server/application/port/output/UpdateServerPortTest.kt
+++ b/server/src/test/kotlin/kpring/server/application/port/output/UpdateServerPortTest.kt
@@ -19,7 +19,7 @@ class UpdateServerPortTest(
     it("유저를 초대가 작동한다.") {
       // given
       val userId = "userId"
-      val server = createServerPort.create(CreateServerRequest("serverName", userId), userId)
+      val server = createServerPort.create(CreateServerRequest("serverName", userId))
 
       // when
       repeat(5) {
@@ -34,7 +34,7 @@ class UpdateServerPortTest(
     it("가입 유저를 추가할 수 있다.") {
       // given
       val ownerId = "ownerId"
-      val server = createServerPort.create(CreateServerRequest("serverName", ownerId), ownerId)
+      val server = createServerPort.create(CreateServerRequest("serverName", ownerId))
       val userId = "userId"
 
       server.registerInvitation(userId)

--- a/server/src/test/kotlin/kpring/server/application/port/output/UpdateServerPortTest.kt
+++ b/server/src/test/kotlin/kpring/server/application/port/output/UpdateServerPortTest.kt
@@ -3,7 +3,7 @@ package kpring.server.application.port.output
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldHaveSize
-import kpring.core.server.dto.request.CreateServerRequest
+import kpring.server.domain.Server
 import kpring.test.testcontainer.SpringTestContext
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ContextConfiguration
@@ -19,33 +19,35 @@ class UpdateServerPortTest(
     it("유저를 초대가 작동한다.") {
       // given
       val userId = "userId"
-      val server = createServerPort.create(CreateServerRequest("serverName", userId))
+      val domain = Server(name = "serverName", users = mutableSetOf(userId))
+      val server = createServerPort.create(domain)
 
       // when
       repeat(5) {
-        updateServerPort.inviteUser(server.id, "test$it")
+        updateServerPort.inviteUser(server.id!!, "test$it")
       }
 
       // then
-      val result = getServerPort.get(server.id)
+      val result = getServerPort.get(server.id!!)
       result.invitedUserIds shouldHaveSize 5
     }
 
     it("가입 유저를 추가할 수 있다.") {
       // given
       val ownerId = "ownerId"
-      val server = createServerPort.create(CreateServerRequest("serverName", ownerId))
+      val domain = Server(name = "serverName", users = mutableSetOf(ownerId))
+      val server = createServerPort.create(domain)
       val userId = "userId"
 
       server.registerInvitation(userId)
-      updateServerPort.inviteUser(server.id, userId)
+      updateServerPort.inviteUser(server.id!!, userId)
       val profile = server.addUser(userId, "name", "/path")
 
       // when
       updateServerPort.addUser(profile)
 
       // then
-      val result = getServerPort.get(server.id)
+      val result = getServerPort.get(server.id!!)
       result.users shouldContain userId
       result.invitedUserIds shouldHaveSize 0
     }

--- a/server/src/test/kotlin/kpring/server/domain/ServerProfileTest.kt
+++ b/server/src/test/kotlin/kpring/server/domain/ServerProfileTest.kt
@@ -11,13 +11,13 @@ class ServerProfileTest : DescribeSpec({
     val userId = "invitedUserId"
     val server =
       Server(
-        id = "serverId",
         name = "serverName",
         invitedUserIds = mutableSetOf("invitedUserId"),
         users = mutableSetOf(userId),
       )
     val serverProfile =
       ServerProfile(
+        id = null,
         server = server,
         name = "name",
         imagePath = "/imagePath",

--- a/server/src/test/kotlin/kpring/server/domain/ServerTest.kt
+++ b/server/src/test/kotlin/kpring/server/domain/ServerTest.kt
@@ -51,4 +51,20 @@ class ServerTest : DescribeSpec({
     // then
     result shouldBe ServerErrorCode.ALREADY_REGISTERED_USER
   }
+
+  it("테마를 지정하지 않은 서버는 기본 테마를 가진다.") {
+    // given & when
+    val server = Server("serverId", "serverName")
+
+    // then
+    server.theme shouldBe Theme.default()
+  }
+
+  it("카테고리를 지정하지 않은 서버는 빈 카테고리 목록을 가진다.") {
+    // given & when
+    val server = Server("serverId", "serverName")
+
+    // then
+    server.categories shouldBe emptySet()
+  }
 })

--- a/server/src/test/kotlin/kpring/server/domain/ServerTest.kt
+++ b/server/src/test/kotlin/kpring/server/domain/ServerTest.kt
@@ -17,7 +17,6 @@ class ServerTest : DescribeSpec({
     // given
     val server =
       Server(
-        "serverId",
         "serverName",
         mutableSetOf(),
         invitedUserIds = mutableSetOf("invitedUserId"),
@@ -35,7 +34,6 @@ class ServerTest : DescribeSpec({
     // given
     val server =
       Server(
-        "serverId",
         "serverName",
         mutableSetOf(),
         invitedUserIds = mutableSetOf("invitedUserId"),
@@ -54,7 +52,7 @@ class ServerTest : DescribeSpec({
 
   it("테마를 지정하지 않은 서버는 기본 테마를 가진다.") {
     // given & when
-    val server = Server("serverId", "serverName")
+    val server = Server("serverName")
 
     // then
     server.theme shouldBe Theme.default()
@@ -62,7 +60,7 @@ class ServerTest : DescribeSpec({
 
   it("카테고리를 지정하지 않은 서버는 빈 카테고리 목록을 가진다.") {
     // given & when
-    val server = Server("serverId", "serverName")
+    val server = Server("serverName")
 
     // then
     server.categories shouldBe emptySet()

--- a/test/src/main/kotlin/kpring/test/restdoc/dsl/RestDocBodyBuilder.kt
+++ b/test/src/main/kotlin/kpring/test/restdoc/dsl/RestDocBodyBuilder.kt
@@ -7,9 +7,15 @@ import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
 class RestDocBodyBuilder {
   val bodyFields = mutableListOf<FieldDescriptor>()
 
-  infix fun FieldDescriptor.mean(description: String) {
-    bodyFields.add(this.description(description))
+  infix fun FieldDescriptor.mean(description: String): FieldDescriptor {
+    val descriptor = this.description(description)
+    bodyFields.add(descriptor)
+    return descriptor
   }
 
   infix fun String.type(type: JsonDataType): FieldDescriptor = fieldWithPath(this).type(type.value)
+
+  infix fun FieldDescriptor.optional(isOptional: Boolean): FieldDescriptor {
+    return if (isOptional) this.optional() else this
+  }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #159 

## 📝작업 내용

- 도메인의 제약을 엔티디에서 반영하도록 리펙터링을 진행하였습니다.
- 서버 생성시 테마와 카테고리를 설정하도록 기능을 확장하였습니다.