### PR TITLE
[Infra] swagger Authorization 헤더 주입 실패 현상 개선

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # jdk 21 환경 구성
       - name: set up jdk 21
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '21'
 
-      # Gradle wrapper 파일 실행 권한주기
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
@@ -29,6 +27,23 @@ jobs:
 
       - name: make api documents
         run: ./gradlew --info openapi3
+
+      - name: configure openapi3 spec
+        run: |
+          yq eval -i '.components.securitySchemes.bearerAuth.type = "http"' ./server/src/main/resources/static/openapi3.yaml
+          yq eval -i '.components.securitySchemes.bearerAuth.scheme = "bearer"' ./server/src/main/resources/static/openapi3.yaml
+          yq eval -i '.components.securitySchemes.bearerAuth.bearerFormat = "JWT"' ./server/src/main/resources/static/openapi3.yaml
+          yq eval -i '.security[0].bearerAuth = []' ./server/src/main/resources/static/openapi3.yaml
+          
+          yq eval -i '.components.securitySchemes.bearerAuth.type = "http"' ./user/src/main/resources/static/openapi3.yaml
+          yq eval -i '.components.securitySchemes.bearerAuth.scheme = "bearer"' ./user/src/main/resources/static/openapi3.yaml
+          yq eval -i '.components.securitySchemes.bearerAuth.bearerFormat = "JWT"' ./user/src/main/resources/static/openapi3.yaml
+          yq eval -i '.security[0].bearerAuth = []' ./user/src/main/resources/static/openapi3.yaml
+          
+          yq eval -i '.components.securitySchemes.bearerAuth.type = "http"' ./auth/src/main/resources/static/openapi3.yaml
+          yq eval -i '.components.securitySchemes.bearerAuth.scheme = "bearer"' ./auth/src/main/resources/static/openapi3.yaml
+          yq eval -i '.components.securitySchemes.bearerAuth.bearerFormat = "JWT"' ./auth/src/main/resources/static/openapi3.yaml
+          yq eval -i '.security[0].bearerAuth = []' ./auth/src/main/resources/static/openapi3.yaml
 
       - name: push image using jib
         run: ./gradlew --info jib


### PR DESCRIPTION
## #️⃣연관된 이슈

- #209 

## 📝작업 내용

- swagger에서 authorization 헤더가 작동하지 않아서 요청을 활용하지 못하는 불편사항을 개선하였습니다.
- 생성된 openapi3.yaml을 ci 과정에서 수정하여 모든 api 요청에 authorization 헤더를 적용하였습니다.
- 필요없는 요청에 대해서도 authorization 헤더가 적용되는 한계점이 있지만 기존에 작동하지 않은 Authorization 스펙 문서를 통해서 필요한 api를 구분하고 요청을 테스트하는 것이 중요하다는 생각에 현재 구현 방식을 체택하였습니다.
