### PR TITLE
[Feat/auth] 로그인 페이지 비밀번호 보이기/감추기, 로딩 인디케이터, 환경변수 설정

### DIFF
--- a/front/.gitignore
+++ b/front/.gitignore
@@ -14,6 +14,7 @@
 # misc
 .DS_Store
 .env.local
+.env
 .env.development.local
 .env.test.local
 .env.production.local

--- a/front/src/api/axiosInstance.ts
+++ b/front/src/api/axiosInstance.ts
@@ -13,7 +13,7 @@ token.ts의 두 함수(validateAccessToken, refreshAccessToken)에서 요청을 
 import axios from "axios";
 
 const axiosInstance = axios.create({
-  baseURL: "http://kpring.duckdns.org",
+  baseURL: process.env.REACT_APP_BASE_URL,
   headers: {
     "Content-Type": "application/json",
   },

--- a/front/src/components/Auth/AuthLayout.tsx
+++ b/front/src/components/Auth/AuthLayout.tsx
@@ -1,8 +1,9 @@
+import { CircularProgress } from "@mui/material";
+
 import { useEffect, useState } from "react";
 import { Outlet, useNavigate } from "react-router-dom";
 import { validateAccessToken } from "../../api/token";
 import { useLoginStore } from "../../store/useLoginStore";
-
 const AuthLayout = () => {
   const navigate = useNavigate();
   const { accessToken } = useLoginStore();
@@ -22,7 +23,11 @@ const AuthLayout = () => {
   }, [accessToken, navigate]);
 
   if (isLoading) {
-    return <div>로딩중</div>;
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <CircularProgress color="primary" size={150} />
+      </div>
+    );
   }
 
   return <Outlet />;

--- a/front/src/components/Auth/JoinBox.tsx
+++ b/front/src/components/Auth/JoinBox.tsx
@@ -43,7 +43,7 @@ function JoinBox() {
   const submitJoin = async () => {
     try {
       const response = await axios.post(
-        "http://kpring.duckdns.org/user/api/v1/user",
+        `${process.env.REACT_APP_BASE_URL}/user/api/v1/user`,
         {
           email: values.email,
           password: values.password,

--- a/front/src/components/Auth/LoginBox.tsx
+++ b/front/src/components/Auth/LoginBox.tsx
@@ -12,9 +12,10 @@ import { LoginValidation } from "../../hooks/LoginValidation";
 import { useLoginStore } from "../../store/useLoginStore";
 import type { AlertInfo } from "../../types/join";
 async function login(email: string, password: string) {
+  console.log(process.env.REACT_APP_BASE_URL);
   try {
     const response = await axios.post(
-      "http://kpring.duckdns.org/user/api/v1/login",
+      `${process.env.REACT_APP_BASE_URL}/user/api/v1/login`,
       { email, password },
       {
         headers: {

--- a/front/src/components/Auth/LoginBox.tsx
+++ b/front/src/components/Auth/LoginBox.tsx
@@ -167,7 +167,7 @@ function LoginBox() {
             helperText={errors.passwordError}
             InputProps={{
               endAdornment: (
-                <IconButton onClick={togglePasswordVisibility} edge="start">
+                <IconButton onClick={togglePasswordVisibility} edge="end">
                   {showPassword ? <VisibilityOffIcon /> : <VisibilityIcon />}
                 </IconButton>
               ),

--- a/front/src/components/Auth/LoginBox.tsx
+++ b/front/src/components/Auth/LoginBox.tsx
@@ -1,8 +1,11 @@
 import LoginIcon from "@mui/icons-material/Login";
 import PersonAddAlt1Icon from "@mui/icons-material/PersonAddAlt1";
+import VisibilityIcon from "@mui/icons-material/Visibility";
+import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
 import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import IconButton from "@mui/material/IconButton";
 import Snackbar, { SnackbarCloseReason } from "@mui/material/Snackbar";
 import TextField from "@mui/material/TextField";
 import axios from "axios";
@@ -12,7 +15,6 @@ import { LoginValidation } from "../../hooks/LoginValidation";
 import { useLoginStore } from "../../store/useLoginStore";
 import type { AlertInfo } from "../../types/join";
 async function login(email: string, password: string) {
-  console.log(process.env.REACT_APP_BASE_URL);
   try {
     const response = await axios.post(
       `${process.env.REACT_APP_BASE_URL}/user/api/v1/login`,
@@ -63,6 +65,7 @@ function LoginBox() {
     message: "",
   });
   const { setTokens } = useLoginStore();
+  const [showPassword, setShowPassword] = useState(false);
 
   const navigate = useNavigate();
 
@@ -74,6 +77,10 @@ function LoginBox() {
     const error = validators[field](value);
     setValues((prevValues) => ({ ...prevValues, [field]: value }));
     setErrors((prevErrors) => ({ ...prevErrors, [`${field}Error`]: error }));
+  };
+
+  const togglePasswordVisibility = () => {
+    setShowPassword(!showPassword);
   };
 
   const clickSubmitHandler = async (e: React.FormEvent) => {
@@ -149,7 +156,7 @@ function LoginBox() {
             required
             id="user-password"
             label="비밀번호"
-            type="password"
+            type={showPassword ? "text" : "password"}
             placeholder="비밀번호를 입력해주세요."
             autoComplete="password"
             variant="standard"
@@ -158,6 +165,13 @@ function LoginBox() {
             onChange={(e) => onChangeHandler("password", e)}
             error={!!errors.passwordError}
             helperText={errors.passwordError}
+            InputProps={{
+              endAdornment: (
+                <IconButton onClick={togglePasswordVisibility} edge="start">
+                  {showPassword ? <VisibilityOffIcon /> : <VisibilityIcon />}
+                </IconButton>
+              ),
+            }}
           />
           <div className="mt-[20px] flex justify-center flex-wrap ">
             <Button

--- a/front/src/hooks/FetchServer.ts
+++ b/front/src/hooks/FetchServer.ts
@@ -4,7 +4,7 @@ import { FetchedServerType } from "../types/server";
 
 // 서버데이터 가져오기
 const fetchServers = async (token: string) => {
-  const url = "http://kpring.duckdns.org/server/api/v1/server";
+  const url = "https://kpring.duckdns.org/server/api/v1/server";
 
   try {
     const response = await axios({

--- a/front/src/hooks/UpdatedServer.ts
+++ b/front/src/hooks/UpdatedServer.ts
@@ -3,7 +3,7 @@ import axios from "axios";
 import { ServerType } from "../types/server";
 
 const createServers = async (data: ServerType, token: string) => {
-  const url = "http://kpring.duckdns.org/server/api/v1/server";
+  const url = "https://kpring.duckdns.org/server/api/v1/server";
 
   console.log(data);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

1. API 요청하는 주소를 환경변수 설정했습니다

2. 로그인 페이지에서 비밀번호 보이기/ 감추기 기능 구현
- 아래 이미지로 설명을 대체하겠습니다.
![show](https://github.com/kSideProject/kpring/assets/143374855/1c935604-e35e-4d0c-bd67-8bd8ef2676e2)

3. 로그인 페이지 진입시 로딩 인디케이터 구현
- 첨부한 이미지는 이미 로그인 중이기 때문에 로딩 인디케이터만  뜨고 메인페이지로 리디렉션됩니다.
- 로딩 인디케이터가 어떤식으로 뜨는지 보여드리 위한 참고 이미지입니다. 
![loading](https://github.com/kSideProject/kpring/assets/143374855/88830933-d2ab-4436-965f-4a10538ff18a)


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
FetchServer.ts와 UpdatedServer.ts는 @jihyun-j 님이 작성하신 코드여서 일단 DM 드린것 처럼 https로만 수정해두었습니다!
추후 원하실때 환경변수화 하시는것을 추천드립니다! 