### PR TITLE
[Server] 서버장 권한 상속 API 구현

### DIFF
--- a/core/src/main/kotlin/kpring/core/server/dto/request/UpdateHostAtServerRequest.kt
+++ b/core/src/main/kotlin/kpring/core/server/dto/request/UpdateHostAtServerRequest.kt
@@ -1,0 +1,6 @@
+package kpring.core.server.dto.request
+
+class UpdateHostAtServerRequest(
+  val userId: String,
+  val userName: String,
+)

--- a/server/src/main/kotlin/kpring/server/adapter/input/rest/RestApiServerController.kt
+++ b/server/src/main/kotlin/kpring/server/adapter/input/rest/RestApiServerController.kt
@@ -7,10 +7,8 @@ import kpring.core.server.dto.ServerSimpleInfo
 import kpring.core.server.dto.request.AddUserAtServerRequest
 import kpring.core.server.dto.request.CreateServerRequest
 import kpring.core.server.dto.request.GetServerCondition
-import kpring.server.application.port.input.AddUserAtServerUseCase
-import kpring.server.application.port.input.CreateServerUseCase
-import kpring.server.application.port.input.DeleteServerUseCase
-import kpring.server.application.port.input.GetServerInfoUseCase
+import kpring.core.server.dto.request.UpdateHostAtServerRequest
+import kpring.server.application.port.input.*
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
@@ -21,6 +19,7 @@ class RestApiServerController(
   val getServerUseCase: GetServerInfoUseCase,
   val addUserAtServerUseCase: AddUserAtServerUseCase,
   val deleteServerUseCase: DeleteServerUseCase,
+  val updateHostAtServerUseCase: UpdateHostAtServerUseCase,
   val authClient: AuthClient,
 ) {
   @PostMapping("")
@@ -102,6 +101,17 @@ class RestApiServerController(
   ): ResponseEntity<Any> {
     val userInfo = authClient.getTokenInfo(token).data!!
     deleteServerUseCase.deleteServer(serverId, userInfo.userId)
+    return ResponseEntity.ok().build()
+  }
+
+  @PatchMapping("/{serverId}")
+  fun updateServerHost(
+    @PathVariable serverId: String,
+    @RequestBody otherUser: UpdateHostAtServerRequest,
+    @RequestHeader("Authorization") token: String,
+  ): ResponseEntity<Any> {
+    val userInfo = authClient.getTokenInfo(token).data!!
+    updateHostAtServerUseCase.updateServerHost(serverId, userInfo.userId, otherUser)
     return ResponseEntity.ok().build()
   }
 }

--- a/server/src/main/kotlin/kpring/server/adapter/output/mongo/UpdateServerPortMongoImpl.kt
+++ b/server/src/main/kotlin/kpring/server/adapter/output/mongo/UpdateServerPortMongoImpl.kt
@@ -1,5 +1,6 @@
 package kpring.server.adapter.output.mongo
 
+import kpring.core.server.dto.request.UpdateHostAtServerRequest
 import kpring.server.adapter.output.mongo.entity.ServerEntity
 import kpring.server.adapter.output.mongo.entity.ServerProfileEntity
 import kpring.server.adapter.output.mongo.repository.ServerProfileRepository
@@ -45,6 +46,22 @@ class UpdateServerPortMongoImpl(
           .and("invitedUserIds").nin(userId),
       ),
       Update().push("invitedUserIds").value(userId),
+      ServerEntity::class.java,
+    )
+  }
+
+  override fun updateServerHost(
+    serverId: String,
+    userId: String,
+    otherUser: UpdateHostAtServerRequest,
+  ) {
+    template.updateFirst(
+      query(
+        where("_id").`is`(serverId)
+          .and("hostId").`is`(userId),
+      ),
+      Update().set("hostId", otherUser.userId)
+        .set("hostName", otherUser.userName),
       ServerEntity::class.java,
     )
   }

--- a/server/src/main/kotlin/kpring/server/adapter/output/mongo/UpdateServerProfilePortMongoImpl.kt
+++ b/server/src/main/kotlin/kpring/server/adapter/output/mongo/UpdateServerProfilePortMongoImpl.kt
@@ -1,0 +1,36 @@
+package kpring.server.adapter.output.mongo
+
+import kpring.server.adapter.output.mongo.entity.ServerProfileEntity
+import kpring.server.adapter.output.mongo.repository.ServerProfileRepository
+import kpring.server.application.port.output.UpdateServerProfilePort
+import kpring.server.domain.ServerProfile
+import kpring.server.domain.ServerRole
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.query.Criteria
+import org.springframework.data.mongodb.core.query.Query
+import org.springframework.data.mongodb.core.query.Update
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional
+class UpdateServerProfilePortMongoImpl(
+  val serverProfileRepository: ServerProfileRepository,
+  val template: MongoTemplate,
+) : UpdateServerProfilePort {
+  override fun updateServerHost(serverProfile: ServerProfile) {
+    val newRole =
+      if (serverProfile.role == ServerRole.OWNER) ServerRole.MEMBER else ServerRole.OWNER
+    template.updateFirst(
+      Query.query(
+        Criteria.where("_id").`is`(serverProfile.server.id)
+          .and("userId").`is`(serverProfile.userId)
+          .and("role").`is`(serverProfile.role),
+      ),
+      Update().set("role", newRole),
+      ServerProfileEntity::class.java,
+    )
+
+    serverProfileRepository.save(ServerProfileEntity(serverProfile))
+  }
+}

--- a/server/src/main/kotlin/kpring/server/application/port/input/UpdateHostAtServerUseCase.kt
+++ b/server/src/main/kotlin/kpring/server/application/port/input/UpdateHostAtServerUseCase.kt
@@ -1,0 +1,11 @@
+package kpring.server.application.port.input
+
+import kpring.core.server.dto.request.UpdateHostAtServerRequest
+
+interface UpdateHostAtServerUseCase {
+  fun updateServerHost(
+    serverId: String,
+    userId: String,
+    otherUser: UpdateHostAtServerRequest,
+  )
+}

--- a/server/src/main/kotlin/kpring/server/application/port/output/UpdateServerPort.kt
+++ b/server/src/main/kotlin/kpring/server/application/port/output/UpdateServerPort.kt
@@ -1,5 +1,6 @@
 package kpring.server.application.port.output
 
+import kpring.core.server.dto.request.UpdateHostAtServerRequest
 import kpring.server.domain.ServerProfile
 
 interface UpdateServerPort {
@@ -8,5 +9,11 @@ interface UpdateServerPort {
   fun inviteUser(
     serverId: String,
     userId: String,
+  )
+
+  fun updateServerHost(
+    serverId: String,
+    userId: String,
+    otherUser: UpdateHostAtServerRequest,
   )
 }

--- a/server/src/main/kotlin/kpring/server/application/port/output/UpdateServerProfilePort.kt
+++ b/server/src/main/kotlin/kpring/server/application/port/output/UpdateServerProfilePort.kt
@@ -1,0 +1,7 @@
+package kpring.server.application.port.output
+
+import kpring.server.domain.ServerProfile
+
+interface UpdateServerProfilePort {
+  fun updateServerHost(serverProfile: ServerProfile)
+}

--- a/server/src/main/kotlin/kpring/server/application/service/ServerService.kt
+++ b/server/src/main/kotlin/kpring/server/application/service/ServerService.kt
@@ -8,19 +8,14 @@ import kpring.core.server.dto.ServerUserInfo
 import kpring.core.server.dto.request.AddUserAtServerRequest
 import kpring.core.server.dto.request.CreateServerRequest
 import kpring.core.server.dto.request.GetServerCondition
+import kpring.core.server.dto.request.UpdateHostAtServerRequest
 import kpring.core.server.dto.response.CreateServerResponse
-import kpring.server.application.port.input.AddUserAtServerUseCase
-import kpring.server.application.port.input.CreateServerUseCase
-import kpring.server.application.port.input.DeleteServerUseCase
-import kpring.server.application.port.input.GetServerInfoUseCase
-import kpring.server.application.port.output.DeleteServerPort
-import kpring.server.application.port.output.GetServerPort
-import kpring.server.application.port.output.GetServerProfilePort
-import kpring.server.application.port.output.SaveServerPort
-import kpring.server.application.port.output.UpdateServerPort
+import kpring.server.application.port.input.*
+import kpring.server.application.port.output.*
 import kpring.server.domain.Category
 import kpring.server.domain.Server
 import kpring.server.domain.ServerAuthority
+import kpring.server.domain.ServerRole
 import kpring.server.util.toInfo
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -31,8 +26,13 @@ class ServerService(
   val getServer: GetServerPort,
   val getServerProfilePort: GetServerProfilePort,
   val updateServerPort: UpdateServerPort,
+  val updateServerProfilePort: UpdateServerProfilePort,
   val deleteServerPort: DeleteServerPort,
-) : CreateServerUseCase, GetServerInfoUseCase, AddUserAtServerUseCase, DeleteServerUseCase {
+) : CreateServerUseCase,
+  GetServerInfoUseCase,
+  AddUserAtServerUseCase,
+  DeleteServerUseCase,
+  UpdateHostAtServerUseCase {
   override fun createServer(req: CreateServerRequest): CreateServerResponse {
     val server =
       createServerPort.create(
@@ -140,5 +140,27 @@ class ServerService(
       throw ServiceException(CommonErrorCode.FORBIDDEN)
     }
     deleteServerPort.delete(serverId)
+  }
+
+  override fun updateServerHost(
+    serverId: String,
+    userId: String,
+    otherUser: UpdateHostAtServerRequest,
+  ) {
+    val hostServerProfile = getServerProfilePort.get(serverId, userId)
+    val newHostServerProfile = getServerProfilePort.get(serverId, otherUser.userId)
+
+    if (hostServerProfile.role != ServerRole.OWNER) {
+      throw ServiceException(CommonErrorCode.FORBIDDEN)
+    }
+
+    val server = hostServerProfile.server
+    server.updateServerHost(otherUser.userId, otherUser.userName)
+    updateServerPort.updateServerHost(serverId, userId, otherUser)
+
+    hostServerProfile.updateServerHost(hostServerProfile)
+    newHostServerProfile.updateServerHost(newHostServerProfile)
+    updateServerProfilePort.updateServerHost(hostServerProfile)
+    updateServerProfilePort.updateServerHost(newHostServerProfile)
   }
 }

--- a/server/src/main/kotlin/kpring/server/domain/Server.kt
+++ b/server/src/main/kotlin/kpring/server/domain/Server.kt
@@ -1,5 +1,6 @@
 package kpring.server.domain
 
+import kpring.core.global.exception.CommonErrorCode
 import kpring.core.global.exception.ServiceException
 import kpring.server.error.ServerErrorCode
 
@@ -20,7 +21,15 @@ class Server(
     hostId: String,
     users: MutableSet<String> = mutableSetOf(),
     invitedUserIds: MutableSet<String> = mutableSetOf(),
-  ) : this(null, name, users, invitedUserIds, initTheme(theme), initCategories(categories), ServerHost(hostName, hostId))
+  ) : this(
+    null,
+    name,
+    users,
+    invitedUserIds,
+    initTheme(theme),
+    initCategories(categories),
+    ServerHost(hostName, hostId),
+  )
 
   companion object {
     // -----------start : 초기화 로직 ------------
@@ -92,6 +101,22 @@ class Server(
       invitedUserIds.add(userId)
     } else {
       throw ServiceException(ServerErrorCode.ALREADY_REGISTERED_USER)
+    }
+  }
+
+  /**
+   * @param userId 권한을 상속받을 유저의 id   *        username 권한을 상속받을 유저의 닉네임
+   * @throws ServiceException userId를 가진 사용자가 해당 서버의 멤버가 아닐 경우
+   */
+  fun updateServerHost(
+    userId: String,
+    username: String,
+  ) {
+    if (users.contains(userId)) {
+      host.id = userId
+      host.name = username
+    } else {
+      throw ServiceException(CommonErrorCode.NOT_FOUND)
     }
   }
 }

--- a/server/src/main/kotlin/kpring/server/domain/ServerHost.kt
+++ b/server/src/main/kotlin/kpring/server/domain/ServerHost.kt
@@ -1,6 +1,6 @@
 package kpring.server.domain
 
 class ServerHost(
-  val name: String,
-  val id: String,
+  var name: String,
+  var id: String,
 )

--- a/server/src/main/kotlin/kpring/server/domain/ServerProfile.kt
+++ b/server/src/main/kotlin/kpring/server/domain/ServerProfile.kt
@@ -6,13 +6,12 @@ class ServerProfile(
   val name: String,
   val imagePath: String,
   val server: Server,
-  val role: ServerRole = ServerRole.MEMBER,
+  var role: ServerRole = ServerRole.MEMBER,
   val bookmarked: Boolean = false,
 ) {
   /**
    * @param authority 확인할 권한
-   * @return 권한이 있으면 true, 없으면 false
-   */
+   * @return 권한이 있으면 true, 없으면 false   */
   fun hasRole(authority: ServerAuthority): Boolean {
     return role.contains(authority)
   }
@@ -22,5 +21,13 @@ class ServerProfile(
    */
   fun dontHasRole(authority: ServerAuthority): Boolean {
     return !hasRole(authority)
+  }
+
+  fun updateServerHost(serverProfile: ServerProfile) {
+    if (serverProfile.role == ServerRole.OWNER) {
+      serverProfile.role = ServerRole.MEMBER
+    } else if (serverProfile.role == ServerRole.MEMBER) {
+      serverProfile.role = ServerRole.OWNER
+    }
   }
 }

--- a/server/src/test/kotlin/kpring/server/application/port/input/AddUserAtServerUseCaseTest.kt
+++ b/server/src/test/kotlin/kpring/server/application/port/input/AddUserAtServerUseCaseTest.kt
@@ -7,10 +7,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kpring.core.global.exception.CommonErrorCode
 import kpring.core.global.exception.ServiceException
-import kpring.server.application.port.output.DeleteServerPort
-import kpring.server.application.port.output.GetServerPort
-import kpring.server.application.port.output.GetServerProfilePort
-import kpring.server.application.port.output.UpdateServerPort
+import kpring.server.application.port.output.*
 import kpring.server.application.service.ServerService
 import kpring.server.domain.ServerProfile
 import kpring.server.domain.ServerRole
@@ -20,8 +17,10 @@ class AddUserAtServerUseCaseTest(
   val getServerPort: GetServerPort = mockk(),
   val getServerProfilePort: GetServerProfilePort = mockk(),
   val updateServerPort: UpdateServerPort = mockk(),
+  val updateServerProfilePort: UpdateServerProfilePort = mockk(),
   val deleteServerPort: DeleteServerPort = mockk(),
-  val service: ServerService = ServerService(mockk(), getServerPort, getServerProfilePort, updateServerPort, deleteServerPort),
+  val service: ServerService =
+    ServerService(mockk(), getServerPort, getServerProfilePort, updateServerPort, updateServerProfilePort, deleteServerPort),
 ) : DescribeSpec({
 
     it("유저 초대시 초대하는 유저가 권한이 없다면 예외를 던진다") {

--- a/server/src/test/kotlin/kpring/server/application/port/input/DeleteServerUseCaseTest.kt
+++ b/server/src/test/kotlin/kpring/server/application/port/input/DeleteServerUseCaseTest.kt
@@ -7,10 +7,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kpring.core.global.exception.CommonErrorCode
 import kpring.core.global.exception.ServiceException
-import kpring.server.application.port.output.DeleteServerPort
-import kpring.server.application.port.output.GetServerPort
-import kpring.server.application.port.output.GetServerProfilePort
-import kpring.server.application.port.output.UpdateServerPort
+import kpring.server.application.port.output.*
 import kpring.server.application.service.ServerService
 import kpring.server.domain.ServerProfile
 import kpring.server.domain.ServerRole
@@ -20,8 +17,10 @@ class DeleteServerUseCaseTest(
   val getServerPort: GetServerPort = mockk(),
   val getServerProfilePort: GetServerProfilePort = mockk(),
   val updateServerPort: UpdateServerPort = mockk(),
+  val updateServerProfilePort: UpdateServerProfilePort = mockk(),
   val deleteServerPort: DeleteServerPort = mockk(),
-  val service: ServerService = ServerService(mockk(), getServerPort, getServerProfilePort, updateServerPort, deleteServerPort),
+  val service: ServerService =
+    ServerService(mockk(), getServerPort, getServerProfilePort, updateServerPort, updateServerProfilePort, deleteServerPort),
 ) : DescribeSpec({
     it("삭제하는 서버에 대한 삭제 권한이 없는 유저라면 예외가 발생한다.") {
       // given


### PR DESCRIPTION
## #️⃣연관된 이슈

- [ ] #203 

## 📝작업 내용

- 로그인한 사용자가 서버에 있는 다른 사용자에게 서버의 호스트 권한을 상속하는 API 를 구현하였습니다.
- 서버장 권한 상속 Controller 테스트코드를 작성하였습니다.
- 서버장 권한 상속 Service 테스트코드를 작성하였습니다.
