### PR TITLE
서버 삭제 기능 버그 수정

### DIFF
--- a/server/src/main/kotlin/kpring/server/adapter/output/mongo/DeleteServerPortMongoImpl.kt
+++ b/server/src/main/kotlin/kpring/server/adapter/output/mongo/DeleteServerPortMongoImpl.kt
@@ -1,5 +1,6 @@
 package kpring.server.adapter.output.mongo
 
+import kpring.server.adapter.output.mongo.repository.ServerProfileRepository
 import kpring.server.adapter.output.mongo.repository.ServerRepository
 import kpring.server.application.port.output.DeleteServerPort
 import org.springframework.stereotype.Component
@@ -7,8 +8,10 @@ import org.springframework.stereotype.Component
 @Component
 class DeleteServerPortMongoImpl(
   val mongoRepository: ServerRepository,
+  val mongoServerProfileRepository: ServerProfileRepository,
 ) : DeleteServerPort {
   override fun delete(serverId: String) {
     mongoRepository.deleteById(serverId)
+    mongoServerProfileRepository.deleteByServerId(serverId)
   }
 }

--- a/server/src/main/kotlin/kpring/server/adapter/output/mongo/repository/ServerProfileRepository.kt
+++ b/server/src/main/kotlin/kpring/server/adapter/output/mongo/repository/ServerProfileRepository.kt
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository
 @Repository
 interface ServerProfileRepository :
   MongoRepository<ServerProfileEntity, String>,
-  QuerydslPredicateExecutor<ServerProfileEntity>
+  QuerydslPredicateExecutor<ServerProfileEntity> {
+  fun deleteByServerId(serverId: String)
+}

--- a/server/src/test/kotlin/kpring/server/adapter/output/mongo/repository/ServerProfileRepositoryTest.kt
+++ b/server/src/test/kotlin/kpring/server/adapter/output/mongo/repository/ServerProfileRepositoryTest.kt
@@ -1,0 +1,48 @@
+package kpring.server.adapter.output.mongo.repository
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import kpring.server.adapter.output.mongo.entity.QServerProfileEntity
+import kpring.server.adapter.output.mongo.entity.ServerProfileEntity
+import kpring.server.domain.ServerRole
+import kpring.test.testcontainer.SpringTestContext
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ContextConfiguration
+
+@SpringBootTest
+@ContextConfiguration(initializers = [SpringTestContext.SpringDataMongo::class])
+class ServerProfileRepositoryTest(
+  serverProfileRepository: ServerProfileRepository,
+) : DescribeSpec({
+
+    it("특정한 서버 아이디를 가지는 프로파일을 삭제한다.") {
+      // given
+      val qProfile = QServerProfileEntity.serverProfileEntity
+      val serverId = "serverId"
+
+      repeat(3) { index ->
+        val serverProfileEntity =
+          ServerProfileEntity(
+            id = null,
+            userId = "userId $index",
+            name = "name $index",
+            imagePath = "imagePath/$index",
+            serverId = serverId,
+            role = ServerRole.MEMBER,
+            bookmarked = false,
+          )
+        serverProfileRepository.save(serverProfileEntity)
+      }
+
+      // when
+      serverProfileRepository.deleteByServerId(serverId)
+
+      // then
+      val result =
+        serverProfileRepository.findAll(
+          qProfile.serverId.eq(serverId),
+        )
+
+      result shouldHaveSize 0
+    }
+  })


### PR DESCRIPTION
## #️⃣연관된 이슈

- #228 

## 📝작업 내용

- 서버 삭제시 관련된 프로필을 삭제하지 않기 때문에 발생한 버그를 수정하였습니다.
- 서버 프로필 일괄 삭제를 위한 기능을 추가하였습니다.
  - 서버의 ID와 연관된 서버 프로필을 일괄 삭제할 수 있습니다. 
