### PR TITLE
[Chat] 채팅방에 Event가 일어났을 때 해당 채팅방을 구독하는 사용자들에게 보내기

### DIFF
--- a/chat/src/main/kotlin/kpring/chat/chat/api/v1/ChatController.kt
+++ b/chat/src/main/kotlin/kpring/chat/chat/api/v1/ChatController.kt
@@ -22,6 +22,7 @@ class ChatController(
   private val authClient: AuthClient,
   private val serverClient: ServerClient,
 ) {
+  @Deprecated("WebSocketChatController를 대신 사용")
   @PostMapping("/chat")
   fun createChat(
     @Validated @RequestBody request: CreateChatRequest,
@@ -43,6 +44,7 @@ class ChatController(
     return ResponseEntity(ApiResponse<Nothing>(status = 201), HttpStatus.CREATED)
   }
 
+  @Deprecated("WebSocketChatController를 대신 사용")
   @GetMapping("/chat")
   fun getChats(
     @RequestParam("type") type: ChatType,
@@ -69,6 +71,7 @@ class ChatController(
     return ResponseEntity.ok().body(ApiResponse(data = result, status = 200))
   }
 
+  @Deprecated("WebSocketChatController를 대신 사용")
   @PatchMapping("/chat")
   fun updateChat(
     @Validated @RequestBody request: UpdateChatRequest,
@@ -79,6 +82,7 @@ class ChatController(
     return ResponseEntity.ok().body(ApiResponse<Nothing>(status = 200))
   }
 
+  @Deprecated("WebSocketChatController를 대신 사용")
   @DeleteMapping("/chat/{chatId}")
   fun deleteChat(
     @PathVariable("chatId") chatId: String,

--- a/chat/src/main/kotlin/kpring/chat/global/config/WebSocketConfig.kt
+++ b/chat/src/main/kotlin/kpring/chat/global/config/WebSocketConfig.kt
@@ -59,15 +59,15 @@ class WebSocketConfig(
       ): Message<*> {
         val simpMessageType = SimpMessageHeaderAccessor.getMessageType(message.headers)
         return when (simpMessageType) {
-          SimpMessageType.CONNECT -> handleConnectMessage(message)
-          SimpMessageType.SUBSCRIBE -> handleSubscribeMessage(message)
+          SimpMessageType.CONNECT -> authenticateAndSetPrincipal(message)
+          SimpMessageType.SUBSCRIBE -> verifyAccess(message)
           else -> message
         }
       }
     }
   }
 
-  private fun handleConnectMessage(message: Message<*>): Message<*> {
+  private fun authenticateAndSetPrincipal(message: Message<*>): Message<*> {
     val headerAccessor = SimpMessageHeaderAccessor.wrap(message)
     val token =
       headerAccessor.getFirstNativeHeader("Authorization")
@@ -84,31 +84,25 @@ class WebSocketConfig(
     return message
   }
 
-  private fun handleSubscribeMessage(message: Message<*>): Message<*> {
+  private fun verifyAccess(message: Message<*>): Message<*> {
     val headerAccessor = SimpMessageHeaderAccessor.wrap(message)
+    val token = getTokenFromHeader(headerAccessor)
+    val contextId = getContextIdFromHeader(headerAccessor)
+    val type = ChatType.valueOf(getContext(headerAccessor))
+    verifyAccessByType(type, token, contextId)
+    return message
+  }
 
-    val token =
-      headerAccessor.getFirstNativeHeader("Authorization")
-        ?.removePrefix("Bearer ")
-        ?: throw GlobalException(ErrorCode.MISSING_TOKEN)
-
-    val contextId =
-      headerAccessor.getFirstNativeHeader("ContextId")
-        ?: throw GlobalException(ErrorCode.MISSING_CONTEXTID)
-
-    val context =
-      headerAccessor.getFirstNativeHeader("Context")
-        ?: throw GlobalException(ErrorCode.MISSING_CONTEXT)
-
-    val type =
-      ChatType.valueOf(context)
-
-    val userId =
-      authClient.getTokenInfo(token).data?.userId
-        ?: throw GlobalException(ErrorCode.INVALID_TOKEN)
-
+  private fun verifyAccessByType(
+    type: ChatType,
+    token: String,
+    contextId: String,
+  ) {
     when (type) {
       ChatType.ROOM -> {
+        val userId =
+          authClient.getTokenInfo(token).data?.userId
+            ?: throw GlobalException(ErrorCode.INVALID_TOKEN)
         accessVerifier.verifyChatRoomAccess(contextId, userId)
       }
       ChatType.SERVER -> {
@@ -119,7 +113,22 @@ class WebSocketConfig(
       }
       else -> throw GlobalException(ErrorCode.INVALID_CONTEXT)
     }
-    return message
+  }
+
+  private fun getTokenFromHeader(headerAccessor: SimpMessageHeaderAccessor): String {
+    return headerAccessor.getFirstNativeHeader("Authorization")
+      ?.removePrefix("Bearer ")
+      ?: throw GlobalException(ErrorCode.MISSING_TOKEN)
+  }
+
+  private fun getContextIdFromHeader(headerAccessor: SimpMessageHeaderAccessor): String {
+    return headerAccessor.getFirstNativeHeader("ContextId")
+      ?: throw GlobalException(ErrorCode.MISSING_CONTEXTID)
+  }
+
+  private fun getContext(headerAccessor: SimpMessageHeaderAccessor): String {
+    return headerAccessor.getFirstNativeHeader("Context")
+      ?: throw GlobalException(ErrorCode.MISSING_CONTEXT)
   }
 
   override fun configureClientInboundChannel(registration: ChannelRegistration) {

--- a/chat/src/main/kotlin/kpring/chat/global/config/WebSocketConfig.kt
+++ b/chat/src/main/kotlin/kpring/chat/global/config/WebSocketConfig.kt
@@ -61,6 +61,7 @@ class WebSocketConfig(
         return when (simpMessageType) {
           SimpMessageType.CONNECT -> authenticateAndSetPrincipal(message)
           SimpMessageType.SUBSCRIBE -> verifyAccess(message)
+          SimpMessageType.MESSAGE -> verifyAccess(message)
           else -> message
         }
       }


### PR DESCRIPTION
## #️⃣연관된 이슈

close #278

## 📝작업 내용

- 채팅방 나가기를 한 유저에게 메시지가 전송되지 않도록 인터셉터의 preSend 메서드에서 메시지 송수신시 권한 확인을 하는 로직을 추가했습니다.
- 기존 인터셉터 코드가 한 메서드 안에 너무 길게 작성되어 있어 메서드를 분리해 코드를 정리했습니다.
