### PR TITLE
[Chat] 채팅방에서 유저 추방하기

### DIFF
--- a/chat/src/main/kotlin/kpring/chat/chatroom/api/v1/WebSocketChatRoomController.kt
+++ b/chat/src/main/kotlin/kpring/chat/chatroom/api/v1/WebSocketChatRoomController.kt
@@ -2,6 +2,7 @@ package kpring.chat.chatroom.api.v1
 
 import kpring.chat.chatroom.service.ChatRoomService
 import kpring.core.chat.chatroom.dto.request.CreateChatRoomRequest
+import kpring.core.chat.chatroom.dto.request.ExpelChatRoomRequest
 import kpring.core.global.dto.response.ApiResponse
 import lombok.RequiredArgsConstructor
 import org.slf4j.Logger
@@ -48,6 +49,16 @@ class WebSocketChatRoomController(
   ) {
     val userId = principal.name
     val result = chatRoomService.joinChatRoom(code, userId)
+    simpMessagingTemplate.convertAndSend("/topic/chatroom/${result.chatRoomId}", ApiResponse(status = 200, data = result.chatResponse))
+  }
+
+  @MessageMapping("/chatroom/expel")
+  fun expelFromChatRoom(
+    @Payload expelChatRoomRequest: ExpelChatRoomRequest,
+    principal: Principal,
+  ) {
+    val userId = principal.name
+    val result = chatRoomService.expelFromChatRoom(expelChatRoomRequest, userId)
     simpMessagingTemplate.convertAndSend("/topic/chatroom/${result.chatRoomId}", ApiResponse(status = 200, data = result.chatResponse))
   }
 }

--- a/chat/src/main/kotlin/kpring/chat/chatroom/model/EventType.kt
+++ b/chat/src/main/kotlin/kpring/chat/chatroom/model/EventType.kt
@@ -6,4 +6,5 @@ enum class EventType(val type: String) {
   CREATED("CREATED"),
   CHAT("CHAT"),
   EXIT("EXIT"),
+  EXPEL("EXPEL"),
 }

--- a/chat/src/main/kotlin/kpring/chat/chatroom/repository/ChatRoomRepository.kt
+++ b/chat/src/main/kotlin/kpring/chat/chatroom/repository/ChatRoomRepository.kt
@@ -10,4 +10,9 @@ interface ChatRoomRepository : MongoRepository<ChatRoom, String> {
     roomId: String,
     userId: String,
   ): Boolean
+
+  fun existsByIdAndOwnerId(
+    roomId: String,
+    ownerId: String,
+  ): Boolean
 }

--- a/chat/src/main/kotlin/kpring/chat/chatroom/service/ChatRoomService.kt
+++ b/chat/src/main/kotlin/kpring/chat/chatroom/service/ChatRoomService.kt
@@ -13,6 +13,7 @@ import kpring.chat.global.util.AccessVerifier
 import kpring.core.chat.chat.dto.response.ChatResponse
 import kpring.core.chat.chat.dto.response.InvitationResponse
 import kpring.core.chat.chatroom.dto.request.CreateChatRoomRequest
+import kpring.core.chat.chatroom.dto.request.ExpelChatRoomRequest
 import kpring.core.chat.model.ChatType
 import kpring.core.chat.model.MessageType
 import org.springframework.stereotype.Service
@@ -68,6 +69,17 @@ class ChatRoomService(
     chatRoom.addUser(userId)
     chatRoomRepository.save(chatRoom)
     return createChatRoomMessage(chatRoom.id!!, "${userId}님이 방에 들어왔습니다.", EventType.ENTER) // TODO : 닉네임으로 변경
+  }
+
+  fun expelFromChatRoom(
+    expelChatRoomRequest: ExpelChatRoomRequest,
+    userId: String,
+  ): ChatWrapper {
+    val chatRoom = getChatRoom(expelChatRoomRequest.chatRoomId)
+    accessVerifier.verifyChatRoomOwner(expelChatRoomRequest.chatRoomId, userId)
+    chatRoom.removeUser(expelChatRoomRequest.expelUserId)
+    chatRoomRepository.save(chatRoom)
+    return createChatRoomMessage(chatRoom.id!!, "${userId}님이 방에서 내보내졌습니다.", EventType.EXPEL) // TODO : 닉네임으로 변경
   }
 
   private fun verifyInvitationExistence(invitationInfo: InvitationInfo) {

--- a/chat/src/main/kotlin/kpring/chat/chatroom/service/ChatRoomService.kt
+++ b/chat/src/main/kotlin/kpring/chat/chatroom/service/ChatRoomService.kt
@@ -79,7 +79,7 @@ class ChatRoomService(
     accessVerifier.verifyChatRoomOwner(expelChatRoomRequest.chatRoomId, userId)
     chatRoom.removeUser(expelChatRoomRequest.expelUserId)
     chatRoomRepository.save(chatRoom)
-    return createChatRoomMessage(chatRoom.id!!, "${userId}님이 방에서 내보내졌습니다.", EventType.EXPEL) // TODO : 닉네임으로 변경
+    return createChatRoomMessage(chatRoom.id!!, "${expelChatRoomRequest.expelUserId}님이 방에서 내보내졌습니다.", EventType.EXPEL) // TODO : 닉네임으로 변경
   }
 
   private fun verifyInvitationExistence(invitationInfo: InvitationInfo) {

--- a/chat/src/main/kotlin/kpring/chat/global/exception/ErrorCode.kt
+++ b/chat/src/main/kotlin/kpring/chat/global/exception/ErrorCode.kt
@@ -14,9 +14,9 @@ enum class ErrorCode(val httpStatus: Int, val message: String) {
   MISSING_TOKEN(HttpStatus.UNAUTHORIZED.value(), "인증 토큰이 누락되었습니다."),
 
   // 403
-  FORBIDDEN_CHATROOM(HttpStatus.FORBIDDEN.value(), "접근이 제한된 채팅방 입니다"),
-  FORBIDDEN_SERVER(HttpStatus.FORBIDDEN.value(), "접근이 제한된 서버 입니다"),
-  FORBIDDEN_CHAT(HttpStatus.FORBIDDEN.value(), "접근이 제한된 채팅 입니다"),
+  FORBIDDEN_CHATROOM(HttpStatus.FORBIDDEN.value(), "채팅방 권한이 없습니다"),
+  FORBIDDEN_SERVER(HttpStatus.FORBIDDEN.value(), "서버 권한이 없습니다"),
+  FORBIDDEN_CHAT(HttpStatus.FORBIDDEN.value(), "채팅 권한이 없습니다"),
 
   // 404
   CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 id로 chatroom을 찾을 수 없습니다"),

--- a/chat/src/main/kotlin/kpring/chat/global/util/AccessVerifier.kt
+++ b/chat/src/main/kotlin/kpring/chat/global/util/AccessVerifier.kt
@@ -30,4 +30,13 @@ class AccessVerifier(
       throw GlobalException(ErrorCode.FORBIDDEN_CHATROOM)
     }
   }
+
+  fun verifyChatRoomOwner(
+    chatRoomId: String,
+    userId: String,
+  ) {
+    if (!chatRoomRepository.existsByIdAndOwnerId(chatRoomId, userId)) {
+      throw GlobalException(ErrorCode.FORBIDDEN_CHATROOM)
+    }
+  }
 }

--- a/chat/src/main/resources/static/chatSample.html
+++ b/chat/src/main/resources/static/chatSample.html
@@ -56,6 +56,10 @@
     <button id="createChatRoomBtn">Create Chat Room</button>
 </div>
 
+<h2>Expel User</h2>
+<input type="text" id="expelUserId" placeholder="Enter user ID to expel"/>
+<button id="expelUserBtn">Expel User</button>
+
 <script>
     let stompClient = null;
 
@@ -107,6 +111,8 @@
         document.getElementById("updateChatBtn").disabled = false;
         document.getElementById("deleteChatBtn").disabled = false;
         document.getElementById("createChatRoomBtn").disabled = false;
+        document.getElementById("expelUserBtn").disabled = false;
+
 
         document.getElementById("sendBtn").addEventListener("click", function () {
             const message = document.getElementById("msg").value;
@@ -209,6 +215,23 @@
                 console.log('Chat room creation request sent!');
             }
         });
+
+        // Expelling a user from the chat room
+        document.getElementById("expelUserBtn").addEventListener("click", function () {
+            const expelUserId = document.getElementById("expelUserId").value;
+
+            if (expelUserId.trim() !== "") {
+                stompClient.send(`/app/chatroom/expel`, {
+                        Authorization: `Bearer ${token}`,
+                        ContextId: chatroomId,
+                        Context: 'ROOM'
+                    },
+                    JSON.stringify({chatRoomId: chatroomId, expelUserId: expelUserId})
+                );
+                document.getElementById("expelUserId").value = "";
+                console.log('Expel request sent for user:', expelUserId);
+            }
+        });
     }
 
     document.addEventListener('DOMContentLoaded', function () {
@@ -218,6 +241,7 @@
         document.getElementById("updateChatBtn").disabled = true;
         document.getElementById("deleteChatBtn").disabled = true;
         document.getElementById("createChatRoomBtn").disabled = true;
+        document.getElementById("expelUserBtn").disabled = true;
 
         document.getElementById("connectBtn").addEventListener("click", function () {
             connectWebSocket();

--- a/chat/src/test/kotlin/kpring/chat/chatroom/ChatRoomServiceTest.kt
+++ b/chat/src/test/kotlin/kpring/chat/chatroom/ChatRoomServiceTest.kt
@@ -1,10 +1,12 @@
 package kpring.chat.chatroom
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
 import io.mockk.*
 import kpring.chat.chat.model.Chat
 import kpring.chat.chat.repository.ChatRepository
+import kpring.chat.chatroom.dto.InvitationInfo
 import kpring.chat.chatroom.model.ChatRoom
 import kpring.chat.chatroom.model.EventType
 import kpring.chat.chatroom.repository.ChatRoomRepository
@@ -12,13 +14,16 @@ import kpring.chat.chatroom.service.ChatRoomService
 import kpring.chat.chatroom.service.InvitationService
 import kpring.chat.global.CommonTest
 import kpring.chat.global.ContextTest
+import kpring.chat.global.exception.ErrorCode
+import kpring.chat.global.exception.GlobalException
 import kpring.chat.global.util.AccessVerifier
 import kpring.core.chat.chatroom.dto.request.CreateChatRoomRequest
+import kpring.core.chat.chatroom.dto.request.ExpelChatRoomRequest
 import kpring.core.chat.model.ChatType
+import kpring.core.chat.model.MessageType
 import java.util.*
 
 class ChatRoomServiceTest : FunSpec({
-
   val chatRoomRepository = mockk<ChatRoomRepository>()
   val chatRepository = mockk<ChatRepository>()
   val invitationService = mockk<InvitationService>()
@@ -26,42 +31,242 @@ class ChatRoomServiceTest : FunSpec({
 
   val chatRoomService = ChatRoomService(chatRoomRepository, chatRepository, invitationService, accessVerifier)
 
-  test("createChatRoom 는 새 ChatRoom을 저장해야 한다") {
-    // Given
-    val request = CreateChatRoomRequest(ContextTest.TEST_MEMBERS)
-    val chatRoom = ChatRoom("test_chatroom_id", CommonTest.TEST_USER_ID, mutableSetOf(CommonTest.TEST_USER_ID))
-    val chat = Chat("chat_id", CommonTest.TEST_USER_ID, ChatType.ROOM, EventType.CHAT, ContextTest.TEST_ROOM_ID, "content")
-    every { chatRepository.save(any()) } returns chat
-    every { chatRoomRepository.save(any()) } returns chatRoom
-
-    // When
-    chatRoomService.createChatRoom(request, CommonTest.TEST_USER_ID)
-
-    // Then
-    verify { chatRoomRepository.save(any()) }
+  beforeTest {
+    clearAllMocks()
   }
 
-  test("exitChatRoom 은 요청한 사람이 members의 일원이라면 삭제해야 한다") {
-    // Given
-    val chatRoom =
-      ChatRoom(
-        id =
-          ContextTest.TEST_ROOM_ID,
-      ).apply {
-        addUsers(ContextTest.TEST_MEMBERS)
+  context("createChatRoom 테스트") {
+    test("채팅방 생성이 성공적으로 이루어져야 한다") {
+      // Given
+      val request = CreateChatRoomRequest(ContextTest.TEST_MEMBERS)
+      val chatRoom =
+        ChatRoom(
+          id = "test_room_id",
+          ownerId = CommonTest.TEST_USER_ID,
+          members = mutableSetOf(CommonTest.TEST_USER_ID),
+        ).apply {
+          addUsers(ContextTest.TEST_MEMBERS)
+        }
+
+      val expectedChat =
+        Chat(
+          id = "chat_id",
+          userId = "",
+          chatType = ChatType.ROOM,
+          eventType = EventType.CREATED,
+          contextId = chatRoom.id!!,
+          content = "방이 생성되었습니다.",
+        )
+
+      every { chatRoomRepository.save(any()) } returns chatRoom
+      every { chatRepository.save(any()) } returns expectedChat
+
+      // When
+      val result = chatRoomService.createChatRoom(request, CommonTest.TEST_USER_ID)
+
+      // Then
+      verify(exactly = 1) { chatRoomRepository.save(any()) }
+      verify(exactly = 1) { chatRepository.save(any()) }
+      result.chatRoomId shouldBe chatRoom.id
+      result.chatResponse.content shouldBe "방이 생성되었습니다."
+      result.chatResponse.messageType shouldBe MessageType.CHAT
+    }
+  }
+
+  context("exitChatRoom 테스트") {
+    test("채팅방 나가기가 성공적으로 이루어져야 한다") {
+      // Given
+      val chatRoomId = ContextTest.TEST_ROOM_ID
+      val userId = CommonTest.TEST_USER_ID
+      val chatRoom =
+        ChatRoom(
+          id = chatRoomId,
+          ownerId = userId,
+          members = mutableSetOf(userId),
+        )
+
+      val expectedChat =
+        Chat(
+          id = "chat_id",
+          userId = "",
+          chatType = ChatType.ROOM,
+          eventType = EventType.EXIT,
+          contextId = chatRoomId,
+          content = "${userId}님이 방에서 나갔습니다.",
+        )
+
+      every { accessVerifier.verifyChatRoomAccess(chatRoomId, userId) } just runs
+      every { chatRoomRepository.findById(chatRoomId) } returns Optional.of(chatRoom)
+      every { chatRoomRepository.save(any()) } returns chatRoom
+      every { chatRepository.save(any()) } returns expectedChat
+
+      // When
+      val result = chatRoomService.exitChatRoom(chatRoomId, userId)
+
+      // Then
+      verify(exactly = 1) { chatRoomRepository.save(any()) }
+      verify(exactly = 1) { chatRepository.save(any()) }
+      result.chatRoomId shouldBe chatRoomId
+      result.chatResponse.content shouldBe "${userId}님이 방에서 나갔습니다."
+    }
+
+    test("존재하지 않는 채팅방에 대한 나가기 요청 시 예외가 발생해야 한다") {
+      // Given
+      val chatRoomId = "non_existent_room_id"
+      val userId = CommonTest.TEST_USER_ID
+
+      every { accessVerifier.verifyChatRoomAccess(chatRoomId, userId) } just runs
+      every { chatRoomRepository.findById(chatRoomId) } returns Optional.empty()
+
+      // When & Then
+      shouldThrow<GlobalException> {
+        chatRoomService.exitChatRoom(chatRoomId, userId)
+      }.getErrorCode() shouldBe ErrorCode.CHATROOM_NOT_FOUND
+    }
+  }
+
+  context("getChatRoomInvitation 테스트") {
+    test("초대 코드가 없는 경우 새로운 코드를 생성해야 한다") {
+      // Given
+      val chatRoomId = ContextTest.TEST_ROOM_ID
+      val userId = CommonTest.TEST_USER_ID
+      val invitationCode = "new_invitation_code"
+      val encodedCode = "encoded_invitation_code"
+
+      every { accessVerifier.verifyChatRoomAccess(chatRoomId, userId) } just runs
+      every { invitationService.getInvitation(userId, chatRoomId) } returns null
+      every { invitationService.setInvitation(userId, chatRoomId) } returns invitationCode
+      every { invitationService.generateKeyAndCode(userId, chatRoomId, invitationCode) } returns encodedCode
+
+      // When
+      val result = chatRoomService.getChatRoomInvitation(chatRoomId, userId)
+
+      // Then
+      verify { invitationService.setInvitation(userId, chatRoomId) }
+      result.code shouldBe encodedCode
+    }
+
+    test("이미 초대 코드가 있는 경우 기존 코드를 반환해야 한다") {
+      // Given
+      val chatRoomId = ContextTest.TEST_ROOM_ID
+      val userId = CommonTest.TEST_USER_ID
+      val existingCode = "existing_code"
+      val encodedCode = "encoded_existing_code"
+
+      every { accessVerifier.verifyChatRoomAccess(chatRoomId, userId) } just runs
+      every { invitationService.getInvitation(userId, chatRoomId) } returns existingCode
+      every { invitationService.generateKeyAndCode(userId, chatRoomId, existingCode) } returns encodedCode
+
+      // When
+      val result = chatRoomService.getChatRoomInvitation(chatRoomId, userId)
+
+      // Then
+      verify(exactly = 0) { invitationService.setInvitation(any(), any()) }
+      result.code shouldBe encodedCode
+    }
+  }
+
+  context("joinChatRoom 테스트") {
+    test("유효한 초대 코드로 채팅방 참여가 성공해야 한다") {
+      // Given
+      val code = "valid_invitation_code"
+      val userId = CommonTest.TEST_USER_ID
+      val chatRoomId = ContextTest.TEST_ROOM_ID
+      val invitationInfo = InvitationInfo("inviter_id", chatRoomId, "invitation_code")
+      val chatRoom = ChatRoom(id = chatRoomId, ownerId = "owner_id", members = mutableSetOf("owner_id"))
+
+      val expectedChat =
+        Chat(
+          id = "chat_id",
+          userId = "",
+          chatType = ChatType.ROOM,
+          eventType = EventType.ENTER,
+          contextId = chatRoomId,
+          content = "${userId}님이 방에 들어왔습니다.",
+        )
+
+      every { invitationService.getInvitationInfoFromCode(code) } returns invitationInfo
+      every { invitationService.getInvitation(invitationInfo.userId, invitationInfo.chatRoomId) } returns invitationInfo.code
+      every { chatRoomRepository.findById(chatRoomId) } returns Optional.of(chatRoom)
+      every { chatRoomRepository.save(any()) } returns chatRoom
+      every { chatRepository.save(any()) } returns expectedChat
+
+      // When
+      val result = chatRoomService.joinChatRoom(code, userId)
+
+      // Then
+      verify { chatRoomRepository.save(any()) }
+      result.chatRoomId shouldBe chatRoomId
+      result.chatResponse.content shouldBe "${userId}님이 방에 들어왔습니다."
+    }
+
+    test("만료된 초대 코드로 채팅방 참여 시 예외가 발생해야 한다") {
+      // Given
+      val code = "expired_invitation_code"
+      val userId = CommonTest.TEST_USER_ID
+      val invitationInfo = InvitationInfo("inviter_id", "room_id", "old_code")
+
+      every { invitationService.getInvitationInfoFromCode(code) } returns invitationInfo
+      every { invitationService.getInvitation(invitationInfo.userId, invitationInfo.chatRoomId) } returns "different_code"
+
+      // When & Then
+      shouldThrow<GlobalException> {
+        chatRoomService.joinChatRoom(code, userId)
+      }.getErrorCode() shouldBe ErrorCode.EXPIRED_INVITATION
+    }
+  }
+
+  context("expelFromChatRoom 테스트") {
+    test("방장이 유저를 추방할 수 있어야 한다") {
+      // Given
+      val chatRoomId = ContextTest.TEST_ROOM_ID
+      val ownerId = CommonTest.TEST_USER_ID
+      val expelUserId = "user_to_expel"
+      val request = ExpelChatRoomRequest(chatRoomId, expelUserId)
+
+      val chatRoom =
+        ChatRoom(
+          id = chatRoomId,
+          ownerId = ownerId,
+          members = mutableSetOf(ownerId, expelUserId),
+        )
+
+      val expectedChat =
+        Chat(
+          id = "chat_id",
+          userId = "",
+          chatType = ChatType.ROOM,
+          eventType = EventType.EXPEL,
+          contextId = chatRoomId,
+          content = "${ownerId}님이 방에서 내보내졌습니다.",
+        )
+
+      every { accessVerifier.verifyChatRoomOwner(any(), any()) } just runs
+      every { chatRoomRepository.findById(any()) } returns Optional.of(chatRoom)
+      every { chatRoomRepository.save(any()) } returns chatRoom
+      every { chatRepository.save(any()) } returns expectedChat
+
+      // When
+      val result = chatRoomService.expelFromChatRoom(request, ownerId)
+
+      // Then
+      verify { chatRoomRepository.save(any()) }
+      result.chatRoomId shouldBe chatRoomId
+      result.chatResponse.content shouldBe "${ownerId}님이 방에서 내보내졌습니다."
+    }
+
+    test("방장이 아닌 사용자가 추방을 시도하면 예외가 발생해야 한다") {
+      // Given
+      val chatRoomId = ContextTest.TEST_ROOM_ID
+      val userId = "non_owner_user"
+      val expelUserId = "user_to_expel"
+      val request = ExpelChatRoomRequest(chatRoomId, expelUserId)
+
+      // When & Then
+      shouldThrow<Throwable> {
+        // 예외 발생 시도
+        chatRoomService.expelFromChatRoom(request, userId)
       }
-    every { chatRoomRepository.findById(chatRoom.id!!) } returns Optional.of(chatRoom)
-    every { chatRoomRepository.save(any()) } returns chatRoom
-    every { chatRoomRepository.existsByIdAndMembersContaining(any(), CommonTest.TEST_USER_ID) } returns true
-    every { accessVerifier.verifyChatRoomAccess(any(), any()) } just runs
-    val chat = Chat("chat_id", CommonTest.TEST_USER_ID, ChatType.ROOM, EventType.CHAT, ContextTest.TEST_ROOM_ID, "content")
-    every { chatRepository.save(any()) } returns chat
-
-    // When
-    chatRoomService.exitChatRoom(chatRoom.id!!, CommonTest.TEST_USER_ID)
-
-    // Then
-    verify { chatRoomRepository.save(chatRoom) }
-    chatRoom.members.shouldNotContain(CommonTest.TEST_USER_ID)
+    }
   }
 })

--- a/chat/src/test/kotlin/kpring/chat/chatroom/ChatRoomServiceTest.kt
+++ b/chat/src/test/kotlin/kpring/chat/chatroom/ChatRoomServiceTest.kt
@@ -258,15 +258,24 @@ class ChatRoomServiceTest : FunSpec({
     test("방장이 아닌 사용자가 추방을 시도하면 예외가 발생해야 한다") {
       // Given
       val chatRoomId = ContextTest.TEST_ROOM_ID
+      val ownerId = "ownerId"
       val userId = "non_owner_user"
       val expelUserId = "user_to_expel"
+      val chatRoom =
+        ChatRoom(
+          id = chatRoomId,
+          ownerId = ownerId,
+          members = mutableSetOf(ownerId, expelUserId),
+        )
       val request = ExpelChatRoomRequest(chatRoomId, expelUserId)
 
+      every { chatRoomRepository.findById(any()) } returns Optional.of(chatRoom)
+      every { accessVerifier.verifyChatRoomOwner(expelUserId, userId) } throws GlobalException(ErrorCode.FORBIDDEN_CHATROOM)
+
       // When & Then
-      shouldThrow<Throwable> {
-        // 예외 발생 시도
+      shouldThrow<GlobalException>({
         chatRoomService.expelFromChatRoom(request, userId)
-      }
+      })
     }
   }
 })

--- a/core/src/main/kotlin/kpring/core/chat/chatroom/dto/request/ExpelChatRoomRequest.kt
+++ b/core/src/main/kotlin/kpring/core/chat/chatroom/dto/request/ExpelChatRoomRequest.kt
@@ -1,0 +1,10 @@
+package kpring.core.chat.chatroom.dto.request
+
+import jakarta.validation.constraints.NotNull
+
+data class ExpelChatRoomRequest(
+  @field:NotNull
+  val expelUserId: String,
+  @field:NotNull
+  val chatRoomId: String,
+)


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #288

## 📝작업 내용

- 채팅방에서 방장이 유저를 내보내는 기능을 구현했습니다

## 💬리뷰 요구사항(선택)

이 부분 테스트를 원래는 다음과 같이 어떤 에러가 나는지 명시하고 있었습니다
```
test("방장이 아닌 사용자가 추방을 시도하면 예외가 발생해야 한다") {
      // Given
      val chatRoomId = ContextTest.TEST_ROOM_ID
      val userId = "non_owner_user"
      val expelUserId = "user_to_expel"
      val request = ExpelChatRoomRequest(chatRoomId, expelUserId)

      // 예외 모킹 시 예외 코드 지정
      every { accessVerifier.verifyChatRoomOwner(chatRoomId, userId) } throws GlobalException(ErrorCode.FORBIDDEN_CHATROOM)

      // When & Then
      val exception =
        shouldThrow<GlobalException> {
          chatRoomService.expelFromChatRoom(request, userId)
        }
      exception.getErrorCode() shouldBe ErrorCode.FORBIDDEN_CHATROOM // 예외 코드 확인
    }
```
자꾸 MockException이 떠서
```
java.lang.AssertionError: Expected exception kpring.chat.global.exception.GlobalException but a MockKException was thrown instead.
	at kpring.chat.chatroom.ChatRoomServiceTest$1$6$2.invokeSuspend(ChatRoomServiceTest.kt:291)
```
어떤 에러든 발생하면 무조건 성공하는 걸로 했는데 다른 해결방법이 있는지 모르겠습니다
```
test("방장이 아닌 사용자가 추방을 시도하면 예외가 발생해야 한다") {
      // Given
      val chatRoomId = ContextTest.TEST_ROOM_ID
      val userId = "non_owner_user"
      val expelUserId = "user_to_expel"
      val request = ExpelChatRoomRequest(chatRoomId, expelUserId)

      // When & Then
      shouldThrow<Throwable> {
        // 예외 발생 시도
        chatRoomService.expelFromChatRoom(request, userId)
      }
    }
```
