### PR TITLE
[Chat] 채팅방에서 유저를 내보낼 때 내보내지는 유저의 WebSocket Subscription 해제

### DIFF
--- a/chat/src/main/kotlin/kpring/chat/chat/model/Chat.kt
+++ b/chat/src/main/kotlin/kpring/chat/chat/model/Chat.kt
@@ -1,8 +1,8 @@
 package kpring.chat.chat.model
 
 import kpring.chat.NoArg
-import kpring.chat.chatroom.model.EventType
 import kpring.chat.global.model.BaseTime
+import kpring.core.chat.chat.dto.response.EventType
 import kpring.core.chat.model.ChatType
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Document

--- a/chat/src/main/kotlin/kpring/chat/chat/service/ChatService.kt
+++ b/chat/src/main/kotlin/kpring/chat/chat/service/ChatService.kt
@@ -4,7 +4,6 @@ import kpring.chat.chat.api.v1.WebSocketChatController
 import kpring.chat.chat.model.Chat
 import kpring.chat.chat.repository.ChatCustomRepository
 import kpring.chat.chat.repository.ChatRepository
-import kpring.chat.chatroom.model.EventType
 import kpring.chat.chatroom.repository.ChatRoomRepository
 import kpring.chat.global.exception.ErrorCode
 import kpring.chat.global.exception.GlobalException
@@ -12,6 +11,7 @@ import kpring.chat.global.util.AccessVerifier
 import kpring.core.chat.chat.dto.request.CreateChatRequest
 import kpring.core.chat.chat.dto.request.UpdateChatRequest
 import kpring.core.chat.chat.dto.response.ChatResponse
+import kpring.core.chat.chat.dto.response.EventType
 import kpring.core.chat.model.ChatType
 import kpring.core.chat.model.MessageType
 import kpring.core.server.dto.ServerSimpleInfo
@@ -45,7 +45,7 @@ class ChatService(
           content = request.content,
         ),
       )
-    return ChatResponse(chat.id!!, userId, MessageType.CHAT, chat.isEdited(), chat.updatedAt.toString(), chat.content)
+    return ChatResponse(chat.id!!, userId, MessageType.CHAT, EventType.CHAT, chat.isEdited(), chat.updatedAt.toString(), chat.content)
   }
 
   fun createServerChat(
@@ -64,7 +64,7 @@ class ChatService(
           content = request.content,
         ),
       )
-    return ChatResponse(chat.id!!, userId, MessageType.CHAT, chat.isEdited(), chat.updatedAt.toString(), chat.content)
+    return ChatResponse(chat.id!!, userId, MessageType.CHAT, EventType.CHAT, chat.isEdited(), chat.updatedAt.toString(), chat.content)
   }
 
   fun getRoomChats(
@@ -101,7 +101,7 @@ class ChatService(
     verifyIfAuthor(userId, chat)
     chat.updateContent(request.content)
     chatRepository.save(chat)
-    return ChatResponse(chat.id!!, userId, MessageType.UPDATE, chat.isEdited(), chat.updatedAt.toString(), chat.content)
+    return ChatResponse(chat.id!!, userId, MessageType.UPDATE, EventType.CHAT, chat.isEdited(), chat.updatedAt.toString(), chat.content)
   }
 
   fun deleteChat(
@@ -111,7 +111,7 @@ class ChatService(
     val chat = chatRepository.findById(chatId).orElseThrow { GlobalException(ErrorCode.CHAT_NOT_FOUND) }
     verifyIfAuthor(userId, chat)
     chatRepository.delete(chat)
-    return ChatResponse(chat.id!!, userId, MessageType.DELETE, chat.isEdited(), chat.updatedAt.toString(), chat.content)
+    return ChatResponse(chat.id!!, userId, MessageType.DELETE, EventType.CHAT, chat.isEdited(), chat.updatedAt.toString(), chat.content)
   }
 
   private fun verifyIfAuthor(
@@ -130,6 +130,7 @@ class ChatService(
           id = chat.id!!,
           sender = chat.userId,
           messageType = MessageType.CHAT,
+          eventType = EventType.CHAT,
           isEdited = chat.isEdited(),
           sentAt = chat.createdAt.toString(),
           content = chat.content,

--- a/chat/src/main/kotlin/kpring/chat/chatroom/api/v1/WebSocketChatRoomController.kt
+++ b/chat/src/main/kotlin/kpring/chat/chatroom/api/v1/WebSocketChatRoomController.kt
@@ -3,6 +3,7 @@ package kpring.chat.chatroom.api.v1
 import kpring.chat.chatroom.service.ChatRoomService
 import kpring.core.chat.chatroom.dto.request.CreateChatRoomRequest
 import kpring.core.chat.chatroom.dto.request.ExpelChatRoomRequest
+import kpring.core.chat.chatroom.dto.response.MessageStatus
 import kpring.core.global.dto.response.ApiResponse
 import lombok.RequiredArgsConstructor
 import org.slf4j.Logger
@@ -60,5 +61,10 @@ class WebSocketChatRoomController(
     val userId = principal.name
     val result = chatRoomService.expelFromChatRoom(expelChatRoomRequest, userId)
     simpMessagingTemplate.convertAndSend("/topic/chatroom/${result.chatRoomId}", ApiResponse(status = 200, data = result.chatResponse))
+    simpMessagingTemplate.convertAndSendToUser(
+      expelChatRoomRequest.expelUserId,
+      "/queue/disconnect",
+      ApiResponse(status = MessageStatus.DISCONNECT.code, MessageStatus.DISCONNECT.description, data = null),
+    )
   }
 }

--- a/chat/src/main/kotlin/kpring/chat/chatroom/service/ChatRoomService.kt
+++ b/chat/src/main/kotlin/kpring/chat/chatroom/service/ChatRoomService.kt
@@ -5,12 +5,12 @@ import kpring.chat.chat.repository.ChatRepository
 import kpring.chat.chatroom.dto.ChatWrapper
 import kpring.chat.chatroom.dto.InvitationInfo
 import kpring.chat.chatroom.model.ChatRoom
-import kpring.chat.chatroom.model.EventType
 import kpring.chat.chatroom.repository.ChatRoomRepository
 import kpring.chat.global.exception.ErrorCode
 import kpring.chat.global.exception.GlobalException
 import kpring.chat.global.util.AccessVerifier
 import kpring.core.chat.chat.dto.response.ChatResponse
+import kpring.core.chat.chat.dto.response.EventType
 import kpring.core.chat.chat.dto.response.InvitationResponse
 import kpring.core.chat.chatroom.dto.request.CreateChatRoomRequest
 import kpring.core.chat.chatroom.dto.request.ExpelChatRoomRequest
@@ -105,7 +105,15 @@ class ChatRoomService(
       )
     return ChatWrapper(
       chatRoomId,
-      ChatResponse(chat.id!!, chat.userId, MessageType.CHAT, chat.isEdited(), chat.updatedAt.toString(), chat.content),
+      ChatResponse(
+        id = chat.id!!,
+        sender = chat.userId,
+        messageType = MessageType.CHAT,
+        isEdited = chat.isEdited(),
+        sentAt = chat.updatedAt.toString(),
+        content = chat.content,
+        eventType = chat.eventType,
+      ),
     )
   }
 

--- a/chat/src/main/kotlin/kpring/chat/global/config/WebSocketConfig.kt
+++ b/chat/src/main/kotlin/kpring/chat/global/config/WebSocketConfig.kt
@@ -42,7 +42,7 @@ class WebSocketConfig(
 
   override fun configureMessageBroker(config: MessageBrokerRegistry) {
     config.setApplicationDestinationPrefixes("/app")
-    config.enableSimpleBroker("/topic")
+    config.enableSimpleBroker("/topic", "/queue")
   }
 
   override fun configureWebSocketTransport(registry: WebSocketTransportRegistration) {
@@ -119,17 +119,17 @@ class WebSocketConfig(
   private fun getTokenFromHeader(headerAccessor: SimpMessageHeaderAccessor): String {
     return headerAccessor.getFirstNativeHeader("Authorization")
       ?.removePrefix("Bearer ")
-      ?: throw GlobalException(ErrorCode.MISSING_TOKEN)
+      ?: throw GlobalException(ErrorCode.MISSING_HEADER_INFO)
   }
 
   private fun getContextIdFromHeader(headerAccessor: SimpMessageHeaderAccessor): String {
     return headerAccessor.getFirstNativeHeader("ContextId")
-      ?: throw GlobalException(ErrorCode.MISSING_CONTEXTID)
+      ?: throw GlobalException(ErrorCode.MISSING_HEADER_INFO)
   }
 
   private fun getContext(headerAccessor: SimpMessageHeaderAccessor): String {
     return headerAccessor.getFirstNativeHeader("Context")
-      ?: throw GlobalException(ErrorCode.MISSING_CONTEXT)
+      ?: throw GlobalException(ErrorCode.MISSING_HEADER_INFO)
   }
 
   override fun configureClientInboundChannel(registration: ChannelRegistration) {

--- a/chat/src/main/kotlin/kpring/chat/global/exception/ErrorCode.kt
+++ b/chat/src/main/kotlin/kpring/chat/global/exception/ErrorCode.kt
@@ -5,8 +5,7 @@ import org.springframework.http.HttpStatus
 enum class ErrorCode(val httpStatus: Int, val message: String) {
   // 400
   INVALID_CHAT_TYPE(HttpStatus.BAD_REQUEST.value(), "잘못된 ChatType입니다."),
-  MISSING_CONTEXTID(HttpStatus.BAD_REQUEST.value(), "채팅방ID 혹은 서버ID가 누락되었습니다."),
-  MISSING_CONTEXT(HttpStatus.BAD_REQUEST.value(), "ChatType이 누락되었습니다."),
+  MISSING_HEADER_INFO(HttpStatus.BAD_REQUEST.value(), "필요한 헤더 정보가 누락되었습니다."),
   INVALID_TOKEN(HttpStatus.BAD_REQUEST.value(), "인증 토큰이 유효하지 않습니다."),
   INVALID_CONTEXT(HttpStatus.BAD_REQUEST.value(), "ChatType이 유효하지 않습니다."),
 

--- a/chat/src/main/resources/static/chatSample.html
+++ b/chat/src/main/resources/static/chatSample.html
@@ -85,6 +85,7 @@
         stompClient.connect(connectHeaders, function (frame) {
             console.log('Connected: ' + frame);
 
+            //채팅방 메시지 구독
             stompClient.subscribe(`/topic/chatroom/${chatroomId}`, function (message) {
                 console.log("Received message:", message.body);
                 const response = JSON.parse(message.body);
@@ -95,6 +96,16 @@
                 Authorization: `Bearer ${token}`,
                 ContextId: chatroomId,
                 Context: 'ROOM'
+            });
+
+            //disconnect 메시지 구독
+            stompClient.subscribe('/user/queue/disconnect', function (message) {
+                const response = JSON.parse(message.body);
+                console.log("Received disconnect message:", response.message);
+
+                //사용자 강제 로그아웃 로직
+                alert(response.message);
+                stompClient.disconnect(() => console.log('Disconnected from WebSocket'));
             });
 
             enableButtonsAfterConnect(token, chatroomId);

--- a/chat/src/test/kotlin/kpring/chat/chat/ChatServiceTest.kt
+++ b/chat/src/test/kotlin/kpring/chat/chat/ChatServiceTest.kt
@@ -8,7 +8,6 @@ import kpring.chat.chat.model.Chat
 import kpring.chat.chat.repository.ChatCustomRepository
 import kpring.chat.chat.repository.ChatRepository
 import kpring.chat.chat.service.ChatService
-import kpring.chat.chatroom.model.EventType
 import kpring.chat.chatroom.repository.ChatRoomRepository
 import kpring.chat.global.ChatTest
 import kpring.chat.global.CommonTest
@@ -19,6 +18,7 @@ import kpring.chat.global.util.AccessVerifier
 import kpring.core.chat.chat.dto.request.CreateChatRequest
 import kpring.core.chat.chat.dto.request.DeleteChatRequest
 import kpring.core.chat.chat.dto.request.UpdateChatRequest
+import kpring.core.chat.chat.dto.response.EventType
 import kpring.core.chat.model.ChatType
 import kpring.core.chat.model.MessageType
 import kpring.core.server.dto.ServerSimpleInfo

--- a/chat/src/test/kotlin/kpring/chat/chat/api/v1/ChatControllerTest.kt
+++ b/chat/src/test/kotlin/kpring/chat/chat/api/v1/ChatControllerTest.kt
@@ -16,6 +16,7 @@ import kpring.core.auth.enums.TokenType
 import kpring.core.chat.chat.dto.request.CreateChatRequest
 import kpring.core.chat.chat.dto.request.UpdateChatRequest
 import kpring.core.chat.chat.dto.response.ChatResponse
+import kpring.core.chat.chat.dto.response.EventType
 import kpring.core.chat.model.ChatType
 import kpring.core.chat.model.MessageType
 import kpring.core.global.dto.response.ApiResponse
@@ -83,6 +84,7 @@ class ChatControllerTest(
             id = ChatTest.TEST_CHAT_ID,
             sender = CommonTest.TEST_USER_ID,
             messageType = MessageType.CHAT,
+            eventType = EventType.CHAT,
             isEdited = false,
             sentAt = LocalDateTime.now().toString(),
             content = content,
@@ -139,6 +141,7 @@ class ChatControllerTest(
               id = ChatTest.TEST_CHAT_ID,
               sender = CommonTest.TEST_USER_ID,
               messageType = MessageType.CHAT,
+              eventType = EventType.CHAT,
               isEdited = true,
               sentAt = LocalDateTime.now().toString(),
               content = ChatTest.CONTENT,
@@ -234,6 +237,7 @@ class ChatControllerTest(
               "data[].id" type JsonDataType.Strings mean "채팅 ID"
               "data[].sender" type JsonDataType.Strings mean "채팅 작성자"
               "data[].messageType" type JsonDataType.Strings mean "메시지 타입"
+              "data[].eventType" type JsonDataType.Strings mean "이벤트 타입"
               "data[].isEdited" type JsonDataType.Booleans mean "메시지가 수정되었는지 여부"
               "data[].sentAt" type JsonDataType.Strings mean "메시지 생성 시간"
               "data[].content" type JsonDataType.Strings mean "메시지 내용"
@@ -255,6 +259,7 @@ class ChatControllerTest(
               id = ChatTest.TEST_CHAT_ID,
               sender = CommonTest.TEST_USER_ID,
               messageType = MessageType.CHAT,
+              eventType = EventType.CHAT,
               isEdited = true,
               sentAt = LocalDateTime.now().toString(),
               content = ChatTest.CONTENT,
@@ -319,6 +324,7 @@ class ChatControllerTest(
               "data[].id" type JsonDataType.Strings mean "채팅 ID"
               "data[].sender" type JsonDataType.Strings mean "채팅 작성자"
               "data[].messageType" type JsonDataType.Strings mean "메시지 타입"
+              "data[].eventType" type JsonDataType.Strings mean "이벤트 타입"
               "data[].isEdited" type JsonDataType.Booleans mean "메시지가 수정되었는지 여부"
               "data[].sentAt" type JsonDataType.Strings mean "메시지 생성 시간"
               "data[].content" type JsonDataType.Strings mean "메시지 내용"
@@ -348,6 +354,7 @@ class ChatControllerTest(
             id = ChatTest.TEST_CHAT_ID,
             sender = CommonTest.TEST_USER_ID,
             messageType = MessageType.CHAT,
+            eventType = EventType.CHAT,
             isEdited = false,
             sentAt = LocalDateTime.now().toString(),
             content = ChatTest.CONTENT,
@@ -437,6 +444,7 @@ class ChatControllerTest(
             id = ChatTest.TEST_CHAT_ID,
             sender = CommonTest.TEST_USER_ID,
             messageType = MessageType.UPDATE,
+            eventType = EventType.CHAT,
             isEdited = true,
             sentAt = LocalDateTime.now().toString(),
             content = ChatTest.CONTENT,
@@ -497,6 +505,7 @@ class ChatControllerTest(
           id = ChatTest.TEST_CHAT_ID,
           sender = CommonTest.TEST_USER_ID,
           messageType = MessageType.DELETE,
+          eventType = EventType.CHAT,
           isEdited = true,
           sentAt = LocalDateTime.now().toString(),
           content = ChatTest.CONTENT,

--- a/chat/src/test/kotlin/kpring/chat/chatroom/ChatRoomServiceTest.kt
+++ b/chat/src/test/kotlin/kpring/chat/chatroom/ChatRoomServiceTest.kt
@@ -8,7 +8,6 @@ import kpring.chat.chat.model.Chat
 import kpring.chat.chat.repository.ChatRepository
 import kpring.chat.chatroom.dto.InvitationInfo
 import kpring.chat.chatroom.model.ChatRoom
-import kpring.chat.chatroom.model.EventType
 import kpring.chat.chatroom.repository.ChatRoomRepository
 import kpring.chat.chatroom.service.ChatRoomService
 import kpring.chat.chatroom.service.InvitationService
@@ -17,6 +16,7 @@ import kpring.chat.global.ContextTest
 import kpring.chat.global.exception.ErrorCode
 import kpring.chat.global.exception.GlobalException
 import kpring.chat.global.util.AccessVerifier
+import kpring.core.chat.chat.dto.response.EventType
 import kpring.core.chat.chatroom.dto.request.CreateChatRoomRequest
 import kpring.core.chat.chatroom.dto.request.ExpelChatRoomRequest
 import kpring.core.chat.model.ChatType

--- a/chat/src/test/kotlin/kpring/chat/chatroom/api/v1/ChatRoomControllerTest.kt
+++ b/chat/src/test/kotlin/kpring/chat/chatroom/api/v1/ChatRoomControllerTest.kt
@@ -8,7 +8,6 @@ import io.mockk.junit5.MockKExtension
 import kpring.chat.chat.model.Chat
 import kpring.chat.chatroom.api.v1.ChatRoomController
 import kpring.chat.chatroom.dto.ChatWrapper
-import kpring.chat.chatroom.model.EventType
 import kpring.chat.chatroom.service.ChatRoomService
 import kpring.chat.global.CommonTest
 import kpring.chat.global.ContextTest
@@ -17,6 +16,7 @@ import kpring.core.auth.client.AuthClient
 import kpring.core.auth.dto.response.TokenInfo
 import kpring.core.auth.enums.TokenType
 import kpring.core.chat.chat.dto.response.ChatResponse
+import kpring.core.chat.chat.dto.response.EventType
 import kpring.core.chat.chat.dto.response.InvitationResponse
 import kpring.core.chat.model.ChatType
 import kpring.core.chat.model.MessageType
@@ -129,7 +129,18 @@ class ChatRoomControllerTest(
             content = content,
           )
         val data =
-          ChatWrapper(chatRoomId, ChatResponse("1", userId, MessageType.CHAT, chat.isEdited(), chat.updatedAt.toString(), chat.content))
+          ChatWrapper(
+            chatRoomId,
+            ChatResponse(
+              id = "1",
+              sender = userId,
+              messageType = MessageType.CHAT,
+              eventType = EventType.ENTER,
+              isEdited = chat.isEdited(),
+              sentAt = chat.updatedAt.toString(),
+              content = chat.content,
+            ),
+          )
 
         every { authClient.getTokenInfo(any()) } returns
           ApiResponse(

--- a/chat/src/test/kotlin/kpring/chat/example/SampleTest.kt
+++ b/chat/src/test/kotlin/kpring/chat/example/SampleTest.kt
@@ -6,7 +6,7 @@ import io.kotest.matchers.shouldBe
 import kpring.chat.chat.model.Chat
 import kpring.chat.chat.model.QChat
 import kpring.chat.chat.repository.ChatRepository
-import kpring.chat.chatroom.model.EventType
+import kpring.core.chat.chat.dto.response.EventType
 import kpring.core.chat.model.ChatType
 import kpring.test.testcontainer.SpringTestContext
 import org.springframework.boot.test.context.SpringBootTest

--- a/core/src/main/kotlin/kpring/core/chat/chat/dto/response/ChatResponse.kt
+++ b/core/src/main/kotlin/kpring/core/chat/chat/dto/response/ChatResponse.kt
@@ -6,6 +6,7 @@ data class ChatResponse(
   val id: String,
   val sender: String,
   val messageType: MessageType,
+  val eventType: EventType,
   val isEdited: Boolean,
   val sentAt: String,
   val content: String,

--- a/core/src/main/kotlin/kpring/core/chat/chat/dto/response/EventType.kt
+++ b/core/src/main/kotlin/kpring/core/chat/chat/dto/response/EventType.kt
@@ -1,4 +1,4 @@
-package kpring.chat.chatroom.model
+package kpring.core.chat.chat.dto.response
 
 enum class EventType(val type: String) {
   ENTER("ENTER"),

--- a/core/src/main/kotlin/kpring/core/chat/chatroom/dto/response/MessageStatus.kt
+++ b/core/src/main/kotlin/kpring/core/chat/chatroom/dto/response/MessageStatus.kt
@@ -1,0 +1,5 @@
+package kpring.core.chat.chatroom.dto.response
+
+enum class MessageStatus(val code: Int, val description: String) {
+  DISCONNECT(1000, "The user should disconnect"),
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #292

## 📝작업 내용
- 추방당한 유저의 개인 구독 queue로 해당 채팅방과 연결을 끊으라는 메시지를 서버측에서 보내게 했습니다

## 💬리뷰 요구사항(선택)
처음에는 서버측에서 아예 웹소켓 구독을 끊어버리고 싶어서 Interceptor의 postSend를 이용해 시도했습니다.
```
@Bean
  fun webSocketInterceptor(): ChannelInterceptor {
    return object : ChannelInterceptor {
      override fun preSend(
        message: Message<*>,
        channel: MessageChannel,
      ): Message<*> {
        val simpMessageType = SimpMessageHeaderAccessor.getMessageType(message.headers)
        return when (simpMessageType) {
          SimpMessageType.CONNECT -> authenticateAndSetPrincipal(message)
          SimpMessageType.SUBSCRIBE -> verifyAccess(message)
          SimpMessageType.MESSAGE -> verifyAccess(message)
          else -> message
        }
      }

      override fun postSend(
        message: Message<*>,
        channel: MessageChannel,
        sent: Boolean,
      ) {
        val headerAccessor = SimpMessageHeaderAccessor.wrap(message)
        val destination = headerAccessor.destination
        if (destination != null && destination == "/chatroom/expel") {
          val expelId = getExpelId(headerAccessor)
          disconnectExpelledUser(expelId)
        }
      }
    }
  }

  private fun disconnectExpelledUser(expelId: String) {
    simpUserRegistry.getUsers().forEach { 
    //특정 채팅방을 unsubscribe 시키고싶었으나 일이 점점 커져갔다
    }
  }
```
저렇게 코드를 작성하고 할 수 있는 방법들을 찾아보았으나 세션을 서버측에서 강제 해제하는 방법은 있어도 구독만 해제하는 방법은 발견하지 못했고 모든 세션을 다 iterate하면서 특정 세션을 찾았을때 그것만 close하는 것도 성능상 좋은 방법은 아니라고 판단했습니다.

https://github.com/rstoyanchev/spring-websocket-portfolio/issues/36
이런 곳에서도 다 클라이언트에서 DISCONNECT FRAME을 보내는게 일반적이라고 하는 것으로 보였습니다.

그래서 그냥 클라이언트가 DISCONNECT FRAME을 보낼 수 있도록 식별되는 메시지를 서버측에서 돌려보내는 것으로 끝냈습니다





