### PR TITLE
fix: user module의 application.yaml에 server url 추가

### DIFF
--- a/user/src/main/resources/application.yaml
+++ b/user/src/main/resources/application.yaml
@@ -14,6 +14,8 @@ spring:
 
 auth:
   url: ${AUTH_SERVICE_URL:http://localhost:8080/api/v1}
+url:
+  server: ${SERVER_SERVICE_URL:http://localhost:8080/}
 
 file:
   path:


### PR DESCRIPTION
## 📝작업 내용

server url을 user module의 application.yaml에 추가해 운영 환경에서 UserController에 주입할 ServerClientConfig Bean이 생성이 깨지는 문제를 해결했습니다.