### PR TITLE
[Fix] User 모듈에 CORS 설정 추가하여 로컬 프론트엔드 요청 허용

### DIFF
--- a/core/src/main/kotlin/kpring/core/global/config/WebFluxStaticResourceConfig.kt
+++ b/core/src/main/kotlin/kpring/core/global/config/WebFluxStaticResourceConfig.kt
@@ -21,6 +21,6 @@ class WebFluxStaticResourceConfig : WebFluxConfigurer {
   override fun addCorsMappings(registry: CorsRegistry) {
     registry.addMapping("/**")
       .allowedOriginPatterns("*")
-      .allowedMethods("GET", "POST", "DELETE", "PUT", "FETCH")
+      .allowedMethods("GET", "POST", "DELETE", "PUT", "PATCH")
   }
 }

--- a/core/src/main/kotlin/kpring/core/global/config/WebMvcStaticResourceConfig.kt
+++ b/core/src/main/kotlin/kpring/core/global/config/WebMvcStaticResourceConfig.kt
@@ -17,6 +17,6 @@ class WebMvcStaticResourceConfig : WebMvcConfigurer {
   override fun addCorsMappings(registry: CorsRegistry) {
     registry.addMapping("/**")
       .allowedOriginPatterns("*")
-      .allowedMethods("GET", "POST", "DELETE", "PUT", "FETCH")
+      .allowedMethods("GET", "POST", "DELETE", "PUT", "PATCH")
   }
 }

--- a/user/src/main/kotlin/kpring/user/config/SecurityConfig.kt
+++ b/user/src/main/kotlin/kpring/user/config/SecurityConfig.kt
@@ -2,13 +2,38 @@ package kpring.user.config
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.web.cors.CorsConfiguration
 
 @Configuration
+@EnableWebSecurity
 class SecurityConfig {
   @Bean
   fun encode(): PasswordEncoder {
     return BCryptPasswordEncoder()
+  }
+
+  @Bean
+  fun filterChain(http: HttpSecurity): SecurityFilterChain {
+    http
+      .cors { cors ->
+        cors.configurationSource {
+          val cors = CorsConfiguration()
+          cors.allowedOrigins = listOf("http://localhost:3000")
+          cors.allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "PATCH")
+          cors.allowedHeaders = listOf("*")
+          cors.allowCredentials = true
+          cors
+        }
+      }
+      .csrf { it.disable() }
+      .formLogin { it.disable() }
+      .httpBasic { }
+
+    return http.build()
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #312

## 📝작업 내용

찾아보니 개발환경에서 front와 back간의 CORS에러를 없앨때는 proxy를 사용하지만
저희처럼 로컬 개발환경 프론트에서 배포된 운영환경 백엔드에 요청을 보내는 경우는 해당하지 않는 것 같아
부득이하게 백엔드에서 cors 설정을 해제했습니다
