### PR TITLE
[CI/CD] 원활한 배포를 위한 Github Actions Workflow 수정 및 변경

### DIFF
--- a/.github/workflows/ci_auth.yml
+++ b/.github/workflows/ci_auth.yml
@@ -1,0 +1,82 @@
+name: Auth micro service CI
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '배포하고자 하는 버전을 입력해주세요. 최신 버전이라면 생략해주세요. (git commit id 앞 8자리)'
+        default: 'latest'
+
+jobs:
+  build:
+    if: github.event.inputs.version == 'latest'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+        name: checkout
+        run: git checkout ${{ github.event.inputs.version }}
+
+      - name: set up jdk 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: make api documents
+        run: ./gradlew --info auth:openapi3
+
+      - name: configure openapi3 spec
+        run: |
+          yq eval -i '.components.securitySchemes.bearerAuth.type = "http"' ./auth/src/main/resources/static/openapi3.yaml
+          yq eval -i '.components.securitySchemes.bearerAuth.scheme = "bearer"' ./auth/src/main/resources/static/openapi3.yaml
+          yq eval -i '.components.securitySchemes.bearerAuth.bearerFormat = "JWT"' ./auth/src/main/resources/static/openapi3.yaml
+          yq eval -i '.security[0].bearerAuth = []' ./auth/src/main/resources/static/openapi3.yaml
+
+      - name: push image using jib
+        run: ./gradlew --info auth:jib
+
+  tagging:
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - if: github.event.inputs.version != 'latest'
+        name: checkout
+        run: git checkout ${{ github.event.inputs.version }}
+
+      - name: set image tag
+        run: |
+          echo "IMAGE_TAG=$(git rev-parse --short=8 HEAD)" >> $GITHUB_ENV
+
+      - name: checkout infra repository
+        uses: actions/checkout@v4
+        with:
+          repository: kSideProject/kpring-infra
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ref: main
+
+      - name: edit infra repository image tag
+        run: |
+          echo 'env(IMAGE_TAG)'
+          yq eval -i '.service.tag = env(IMAGE_TAG)' ./charts/auth/values.yaml
+
+      - name: commit
+        uses: leigholiver/commit-with-deploy-key@v1.0.4
+        with:
+          source: .
+          destination_repo: kSideProject/kpring-infra
+          deploy_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          commit_message: 'ci: update auth image version=${{ github.event.inputs.version }}'

--- a/.github/workflows/ci_front.yml
+++ b/.github/workflows/ci_front.yml
@@ -1,0 +1,70 @@
+name: Frontend Nginx micro service CI
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '배포하고자 하는 버전을 입력해주세요. 최신 버전이라면 생략해주세요. (git commit id 앞 8자리)'
+        default: 'latest'
+
+jobs:
+  build:
+    if: github.event.inputs.version == 'latest'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+        name: checkout
+        run: git checkout ${{ github.event.inputs.version }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      # Build Docker image
+      - name: Build Docker Image
+        run: |
+          docker build -t kpring/front_app:$(git rev-parse --short=8 HEAD) .
+
+      # Push Docker image to DockerHub
+      - name: Push Docker Image to DockerHub
+        run: |
+          docker push kpring/front_app:$(git rev-parse --short=8 HEAD)
+
+  tagging:
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - if: github.event.inputs.version != 'latest'
+        name: checkout
+        run: git checkout ${{ github.event.inputs.version }}
+
+      - name: set image tag
+        run: |
+          echo "IMAGE_TAG=$(git rev-parse --short=8 HEAD)" >> $GITHUB_ENV
+
+      - name: checkout infra repository
+        uses: actions/checkout@v4
+        with:
+          repository: kSideProject/kpring-infra
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ref: main
+
+      - name: edit infra repository image tag
+        run: |
+          echo 'env(IMAGE_TAG)'
+          yq eval -i '.image.tag = env(IMAGE_TAG)' ./charts/front/values.yaml
+
+      - name: commit
+        uses: leigholiver/commit-with-deploy-key@v1.0.4
+        with:
+          source: .
+          destination_repo: kSideProject/kpring-infra
+          deploy_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          commit_message: 'ci: update frontend image version=${{ github.event.inputs.version }}'

--- a/.github/workflows/ci_server.yml
+++ b/.github/workflows/ci_server.yml
@@ -1,14 +1,21 @@
-name: CI
+name: Server micro service CI
 
 on:
-  push:
-    branches: [ main ] # push 되었을 때, 실행
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '배포하고자 하는 버전을 입력해주세요. 최신 버전이라면 생략해주세요. (git commit id 앞 8자리)'
+        default: 'latest'
 
 jobs:
   build:
+    if: github.event.inputs.version == 'latest'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+        name: checkout
+        run: git checkout ${{ github.event.inputs.version }}
 
       - name: set up jdk 21
         uses: actions/setup-java@v4
@@ -16,17 +23,17 @@ jobs:
           distribution: 'zulu'
           java-version: '21'
 
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
       - name: make api documents
-        run: ./gradlew --info openapi3
+        run: ./gradlew --info server:openapi3
 
       - name: configure openapi3 spec
         run: |
@@ -34,19 +41,9 @@ jobs:
           yq eval -i '.components.securitySchemes.bearerAuth.scheme = "bearer"' ./server/src/main/resources/static/openapi3.yaml
           yq eval -i '.components.securitySchemes.bearerAuth.bearerFormat = "JWT"' ./server/src/main/resources/static/openapi3.yaml
           yq eval -i '.security[0].bearerAuth = []' ./server/src/main/resources/static/openapi3.yaml
-          
-          yq eval -i '.components.securitySchemes.bearerAuth.type = "http"' ./user/src/main/resources/static/openapi3.yaml
-          yq eval -i '.components.securitySchemes.bearerAuth.scheme = "bearer"' ./user/src/main/resources/static/openapi3.yaml
-          yq eval -i '.components.securitySchemes.bearerAuth.bearerFormat = "JWT"' ./user/src/main/resources/static/openapi3.yaml
-          yq eval -i '.security[0].bearerAuth = []' ./user/src/main/resources/static/openapi3.yaml
-          
-          yq eval -i '.components.securitySchemes.bearerAuth.type = "http"' ./auth/src/main/resources/static/openapi3.yaml
-          yq eval -i '.components.securitySchemes.bearerAuth.scheme = "bearer"' ./auth/src/main/resources/static/openapi3.yaml
-          yq eval -i '.components.securitySchemes.bearerAuth.bearerFormat = "JWT"' ./auth/src/main/resources/static/openapi3.yaml
-          yq eval -i '.security[0].bearerAuth = []' ./auth/src/main/resources/static/openapi3.yaml
 
       - name: push image using jib
-        run: ./gradlew --info jib
+        run: ./gradlew --info server:jib
 
   tagging:
     needs:
@@ -56,7 +53,11 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - name: set tag
+      - if: github.event.inputs.version != 'latest'
+        name: checkout
+        run: git checkout ${{ github.event.inputs.version }}
+
+      - name: set image tag
         run: |
           echo "IMAGE_TAG=$(git rev-parse --short=8 HEAD)" >> $GITHUB_ENV
 
@@ -67,12 +68,10 @@ jobs:
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
           ref: main
 
-      - name: edit infra repository tag
+      - name: edit infra repository image tag
         run: |
           echo 'env(IMAGE_TAG)'
           yq eval -i '.service.tag = env(IMAGE_TAG)' ./charts/server/values.yaml
-          yq eval -i '.service.tag = env(IMAGE_TAG)' ./charts/user/values.yaml
-          yq eval -i '.service.tag = env(IMAGE_TAG)' ./charts/auth/values.yaml
 
       - name: commit
         uses: leigholiver/commit-with-deploy-key@v1.0.4
@@ -80,4 +79,4 @@ jobs:
           source: .
           destination_repo: kSideProject/kpring-infra
           deploy_key: ${{ secrets.SSH_PRIVATE_KEY }}
-          commit_message: 'ci: update tag to env(IMAGE_TAG)'
+          commit_message: 'ci: update server image version=${{ github.event.inputs.version }}'

--- a/.github/workflows/ci_user.yml
+++ b/.github/workflows/ci_user.yml
@@ -1,0 +1,82 @@
+name: User micro service CI
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '배포하고자 하는 버전을 입력해주세요. 최신 버전이라면 생략해주세요. (git commit id 앞 8자리)'
+        default: 'latest'
+
+jobs:
+  build:
+    if: github.event.inputs.version == 'latest'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+        name: checkout
+        run: git checkout ${{ github.event.inputs.version }}
+
+      - name: set up jdk 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: make api documents
+        run: ./gradlew --info user:openapi3
+
+      - name: configure openapi3 spec
+        run: |
+          yq eval -i '.components.securitySchemes.bearerAuth.type = "http"' ./user/src/main/resources/static/openapi3.yaml
+          yq eval -i '.components.securitySchemes.bearerAuth.scheme = "bearer"' ./user/src/main/resources/static/openapi3.yaml
+          yq eval -i '.components.securitySchemes.bearerAuth.bearerFormat = "JWT"' ./user/src/main/resources/static/openapi3.yaml
+          yq eval -i '.security[0].bearerAuth = []' ./user/src/main/resources/static/openapi3.yaml
+
+      - name: push image using jib
+        run: ./gradlew --info user:jib
+
+  tagging:
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - if: github.event.inputs.version != 'latest'
+        name: checkout
+        run: git checkout ${{ github.event.inputs.version }}
+
+      - name: set image tag
+        run: |
+          echo "IMAGE_TAG=$(git rev-parse --short=8 HEAD)" >> $GITHUB_ENV
+
+      - name: checkout infra repository
+        uses: actions/checkout@v4
+        with:
+          repository: kSideProject/kpring-infra
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ref: main
+
+      - name: edit infra repository image tag
+        run: |
+          echo 'env(IMAGE_TAG)'
+          yq eval -i '.service.tag = env(IMAGE_TAG)' ./charts/user/values.yaml
+
+      - name: commit
+        uses: leigholiver/commit-with-deploy-key@v1.0.4
+        with:
+          source: .
+          destination_repo: kSideProject/kpring-infra
+          deploy_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          commit_message: 'ci: update user image version=${{ github.event.inputs.version }}'


### PR DESCRIPTION
- #323 

변경사항을 배포하는 과정이 복잡하기 때문에 이를 개선하기 위한 워크 플로우를 수정합니다.

## 📝작업 내용
- 쉬운 롤백을 위한 수동 workflow 추가
- 통합 배포가 아니라 개발한 서비스를 분리하여 배포 가능하도록 수정
- 커밋 id를 통해서 배포하도록 구성하여 다른 브랜치라도 배포가 가능

### 변경 파일
- ci.yml 삭제
- ci/server.yml workflow 추가
- ci/user.yml workflow 추가
- ci/auth.yml workflow 추가
- ci/front.yml workflow 추가

main push 시에 자동 배포되는 구성을 수동으로 배포하도록 변경하였습니다. 따라서 롤백이 가능하도록 변경하였습니다.

## 💬리뷰 요구사항
- 오류 사항이 있는지 살펴봐주세요.
- 배포시에 다른 요구사항이 있다면 의견을 주세요.
- 프론트 배포 설정이 잘 되었는지 살펴봐 주세요. front/Dockerfile 을 기반으로 구성하였습니다.